### PR TITLE
Consolidate employer data onto portfolio_employers and add a persiste…

### DIFF
--- a/docs/mariadb-setup.sql
+++ b/docs/mariadb-setup.sql
@@ -35,6 +35,43 @@ CREATE TABLE IF NOT EXISTS portfolio_projects (
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Single source of truth for work history: the homepage Experience cards, the
+-- header's "Work" dropdown, and /experience/[slug] pages are all driven by
+-- this table (plus its two child tables below).
+CREATE TABLE IF NOT EXISTS portfolio_employers (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  slug VARCHAR(150) NOT NULL UNIQUE,
+  name VARCHAR(255) NOT NULL,
+  title VARCHAR(255) NOT NULL,
+  start_date DATE NOT NULL,
+  end_date DATE NULL, -- NULL means "current / present"
+  location VARCHAR(150) DEFAULT NULL,
+  summary VARCHAR(500) NOT NULL, -- short blurb for the homepage preview card
+  description TEXT NOT NULL,     -- longer intro shown on the employer's own page
+  sort_order INT DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Short bullet points shown under "What I worked on" on the employer page.
+CREATE TABLE IF NOT EXISTS portfolio_employer_highlights (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  employer_id INT NOT NULL,
+  highlight TEXT NOT NULL,
+  sort_order INT DEFAULT 0,
+  FOREIGN KEY (employer_id) REFERENCES portfolio_employers(id) ON DELETE CASCADE
+);
+
+-- Case-study cards shown under "Featured work" on the employer page.
+CREATE TABLE IF NOT EXISTS portfolio_employer_case_studies (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  employer_id INT NOT NULL,
+  title VARCHAR(255) NOT NULL,
+  summary TEXT NOT NULL,
+  image VARCHAR(255) DEFAULT NULL,
+  sort_order INT DEFAULT 0,
+  FOREIGN KEY (employer_id) REFERENCES portfolio_employers(id) ON DELETE CASCADE
+);
+
 INSERT INTO portfolio_content (scope, `key`, `value`, sort_order) VALUES
 ('homepage', 'heroEyebrow', '"Family-first • software engineer • builder"', 1),
 ('homepage', 'heroTitle', '"I build practical internal tools that make teams faster, clearer, and more confident."', 2),
@@ -72,3 +109,63 @@ INSERT INTO portfolio_projects (title, summary, image, company, company_slug, co
 ('Phase 10 Dice', 'Developed the Phase 10 Dice game in C++ as the final project for CS101 at Ivy Tech.', '/images/projects/20.jpg', 'Ivy Tech', 'ivy-tech', 'emerald', 1, 1),
 ('Accessibility Website', 'Built a website teaching accessibility concepts using Agile methodologies as part of a Purdue University project management course.', '/images/projects/21.jpg', 'Purdue University', 'purdue-university', 'violet', 1, 1),
 ('Distribution Center - Cookout Giveaway', 'Built a badge-based raffle application for the Sweetwater Distribution Center to manage employee prizes and winners at a cookout event.', '/images/projects/22.jpg', 'Sweetwater Sound', 'sweetwater', 'sky', 1, 1);
+
+-- Employers: single source of truth for homepage Experience cards, the
+-- header's Work dropdown, and /experience/[slug] pages.
+INSERT INTO portfolio_employers (slug, name, title, start_date, end_date, location, summary, description, sort_order) VALUES
+('packaging-personified', 'Packaging Personified, Inc.', 'Software Engineer', '2025-10-01', NULL, 'Warsaw, IN', 'Building internal Retool applications for production, compliance, accounting, and operations teams.', 'Building internal Retool applications for production, compliance, accounting, and operations teams, including a Yield Report tool for tracking job performance and material usage, and consolidated EPA reporting for Illinois and Michigan compliance. Created reusable shared modules and delivered a 40%+ performance improvement to the Press WIP application while training managers and end users on Retool best practices.', 1),
+('sweetwater-sound', 'Sweetwater Sound', 'Software Engineer', '2021-05-01', '2025-08-01', 'Fort Wayne, IN', 'Delivered internal tools, workflow automations, and revenue-driving platforms across accounting, commerce, and merchandising.', 'Sole developer of Avalara''s Exemption Certificate Management System, saving the tax team 160+ hours of manual validation per month, and integrated PayPal''s Braintree system into the CRM to help launch Gear Exchange, which generated over $1M in sales within months. Also built a dynamic Price Management Platform that drove $4M in revenue in under a month, alongside daily-use internal tools across departments.', 2),
+('zimmer-biomet', 'Zimmer Biomet', 'Information Technology Intern', '2020-10-01', '2021-05-01', 'Warsaw, IN', 'Supported device deployment and IT operations across campuses in the Warsaw area.', 'Imaged and deployed company devices, issued laptops and accessories, and performed hardware upgrades for onboarding and refresh cycles. Delivered devices to campuses across the Warsaw area as part of IT operations support.', 3),
+('census-bureau', 'United States Census Bureau', 'Post-Enumeration Surveyor', '2020-01-01', '2020-10-01', 'Warsaw, IN', 'Collected population data door-to-door for the U.S. Census Bureau''s Post-Enumeration Survey.', 'Conducted in-person interviews to collect population data for the Post-Enumeration Survey, ensuring census accuracy while complying with strict federal confidentiality guidelines. Maintained detailed activity logs and navigated difficult resident interactions with calm, professional de-escalation.', 4),
+('staples', 'Staples', 'Technology Sales Associate', '2018-06-01', '2019-05-01', 'Warsaw, IN', 'Helped customers find the right technology products as a top-performing sales associate.', 'Assessed customer needs and guided them to the right technology products, consistently ranking as the top store in Northern Indiana for several consecutive weeks. Stayed current on promotions and product launches to support sales goals.', 5),
+('blacks-concrete-construction', 'Black''s Concrete Construction', 'Concrete Laborer', '2016-06-01', '2017-03-01', 'Warsaw, IN', 'Handled nearly every phase of residential concrete work on a small, hands-on crew.', 'Worked as part of a small 2-3 person crew handling nearly every phase of residential concrete work, including driving the company truck, forming, pouring, finishing, cutting, cleaning, sealing, and stamping. Gained hands-on versatility and a strong work ethic from taking on broad responsibility within a lean, close-knit team.', 6)
+ON DUPLICATE KEY UPDATE name = VALUES(name), title = VALUES(title), start_date = VALUES(start_date), end_date = VALUES(end_date), location = VALUES(location), summary = VALUES(summary), description = VALUES(description), sort_order = VALUES(sort_order);
+
+-- Highlights and case studies are seed-only (no natural unique key), so clear
+-- any existing rows for these employers before re-inserting on a fresh run.
+DELETE h FROM portfolio_employer_highlights h JOIN portfolio_employers e ON e.id = h.employer_id
+  WHERE e.slug IN ('packaging-personified', 'sweetwater-sound', 'zimmer-biomet', 'census-bureau', 'staples', 'blacks-concrete-construction');
+DELETE c FROM portfolio_employer_case_studies c JOIN portfolio_employers e ON e.id = c.employer_id
+  WHERE e.slug IN ('packaging-personified', 'sweetwater-sound', 'zimmer-biomet');
+
+INSERT INTO portfolio_employer_highlights (employer_id, highlight, sort_order)
+SELECT e.id, h.highlight, h.sort_order FROM portfolio_employers e
+JOIN (
+  SELECT 'packaging-personified' AS slug, 1 AS sort_order, 'Developed and maintained internal applications using Retool, PostgreSQL, SQL, and JavaScript for production, compliance, accounting, and operations teams.' AS highlight
+  UNION ALL SELECT 'packaging-personified', 2, 'Built the Yield Report application to track company and customer job performance, material usage, production efficiency, and operational trends.'
+  UNION ALL SELECT 'packaging-personified', 3, 'Consolidated spreadsheets and multiple data sources into EPA reporting tools supporting environmental compliance workflows for Illinois and Michigan facilities.'
+  UNION ALL SELECT 'packaging-personified', 4, 'Created reusable tools, including a standardized Header Module and scalable Location Swap application, to improve consistency across Retool applications.'
+  UNION ALL SELECT 'packaging-personified', 5, 'Optimized applications and automated workflows for performance, reliability, and usability, including improving Press WIP processing speed by more than 40%.'
+  UNION ALL SELECT 'packaging-personified', 6, 'Trained managers, developers, company owners, and end users on Retool functionality, application workflows, and development best practices.'
+  UNION ALL SELECT 'sweetwater-sound', 1, 'Sole developer on the implementation of Avalara''s Exemption Certificate Management System (ECMS), saving the tax team the equivalent of 160+ hours of validating exemption certificates per month.'
+  UNION ALL SELECT 'sweetwater-sound', 2, 'Integrated PayPal''s GraphQL-based Braintree system into the CRM to help launch Gear Exchange, which saw over $1M in sales between users within its first few months.'
+  UNION ALL SELECT 'sweetwater-sound', 3, 'Built and deployed a Price Management Platform used by merchandising to adjust pricing dynamically, resulting in $4M in increased revenue in under a month.'
+  UNION ALL SELECT 'sweetwater-sound', 4, 'Provided a Turkey Handout application for Sweetwater''s Thanksgiving giveaway within 72 hours, allowing the campus events team to hand out turkeys and gift cards to 2,500 employees.'
+  UNION ALL SELECT 'sweetwater-sound', 5, 'Contributed to internal software development by designing scalable features, debugging production issues, and delivering tools used daily across multiple departments.'
+  UNION ALL SELECT 'zimmer-biomet', 1, 'Imaged and prepared company devices with software for deployment.'
+  UNION ALL SELECT 'zimmer-biomet', 2, 'Issued laptops, accessories, and performed hardware upgrades for onboarding and refreshing hardware.'
+  UNION ALL SELECT 'zimmer-biomet', 3, 'Used a company vehicle to deliver devices to various campuses in the Warsaw area.'
+  UNION ALL SELECT 'census-bureau', 1, 'Performed interviews at addresses within assigned blocks to collect population data as part of the Post-Enumeration Survey, ensuring census accuracy.'
+  UNION ALL SELECT 'census-bureau', 2, 'Complied with strict federal guidelines and confidentiality rules for gathering demographic and housing information.'
+  UNION ALL SELECT 'census-bureau', 3, 'Recorded information using a government-issued laptop, maintaining hour logs, mileage, and case activity.'
+  UNION ALL SELECT 'census-bureau', 4, 'Navigated difficult or uncooperative situations by calmly diffusing tensions with hesitant or hostile residents.'
+  UNION ALL SELECT 'staples', 1, 'Asked customers pertinent questions to assess and determine their needs, guiding them to the correct product.'
+  UNION ALL SELECT 'staples', 2, 'Answered questions, explained product features, and gave honest input based on customer needs.'
+  UNION ALL SELECT 'staples', 3, 'Used Staples sales strategies to become the number one store in Northern Indiana for several weeks straight.'
+  UNION ALL SELECT 'staples', 4, 'Stayed up to date on weekly promotions and product launches to best support customers and hit sales goals.'
+  UNION ALL SELECT 'blacks-concrete-construction', 1, 'Drove the company truck and handled nearly every phase of residential concrete work on a lean 2-3 person crew.'
+  UNION ALL SELECT 'blacks-concrete-construction', 2, 'Performed forming, pouring, finishing, cutting, cleaning, sealing, and stamping across a wide range of jobs.'
+  UNION ALL SELECT 'blacks-concrete-construction', 3, 'Gained hands-on versatility and a strong work ethic from taking on broad responsibility within a small, close-knit team.'
+) h ON h.slug = e.slug;
+
+INSERT INTO portfolio_employer_case_studies (employer_id, title, summary, image, sort_order)
+SELECT e.id, c.title, c.summary, c.image, c.sort_order FROM portfolio_employers e
+JOIN (
+  SELECT 'packaging-personified' AS slug, 'Yield Report' AS title, 'A reporting tool for tracking production and customer performance trends using operational data from multiple sources.' AS summary, '/images/projects/ppi-yield-report.svg' AS image, 1 AS sort_order
+  UNION ALL SELECT 'packaging-personified', 'EPA Reporting', 'A compliance-oriented reporting workflow that combines spreadsheets and source data into a more maintainable reporting experience.', '/images/projects/ppi-epa-reporting.svg', 2
+  UNION ALL SELECT 'packaging-personified', 'Press WIP Optimization', 'A performance-focused workflow improvement project that reduced processing time and simplified day-to-day operations.', '/images/projects/ppi-press-wip.svg', 3
+  UNION ALL SELECT 'sweetwater-sound', 'Turkey Handout App', 'A fast-turnaround internal tool that made holiday employee gifting easier and more organized.', '/images/projects/1.png', 1
+  UNION ALL SELECT 'sweetwater-sound', 'Gear Exchange', 'Helped support commerce workflows and secure payment integration for a rapidly growing platform.', '/images/projects/2.jpg', 2
+  UNION ALL SELECT 'sweetwater-sound', 'DementiaTrack', 'A capstone project that combined thoughtful software design with practical analytics.', '/images/projects/9.jpg', 3
+  UNION ALL SELECT 'zimmer-biomet', 'Device Deployment Support', 'Helped prepare and configure systems for company use in a structured, detail-focused workflow.', '/images/projects/zimmer-biomet.jpg', 1
+) c ON c.slug = e.slug;

--- a/docs/migrations/001_normalize_employers.sql
+++ b/docs/migrations/001_normalize_employers.sql
@@ -1,0 +1,75 @@
+-- Migration for an EXISTING portfolio_employers table (created before this
+-- migration only had: id, slug, name, title, date_range, location,
+-- description, sort_order, created_at).
+--
+-- Run each step in order against your live database.
+--
+-- Back up first:
+--   mysqldump -u root -p portfolio portfolio_employers > portfolio_employers_backup.sql
+
+-- ----------------------------------------------------------------------
+-- Step 1: Add the new columns (nullable for now, so this is safe to run
+-- even with existing rows).
+-- ----------------------------------------------------------------------
+ALTER TABLE portfolio_employers
+  ADD COLUMN start_date DATE NULL AFTER title,
+  ADD COLUMN end_date DATE NULL AFTER start_date,
+  ADD COLUMN summary VARCHAR(500) NULL AFTER location;
+
+-- ----------------------------------------------------------------------
+-- Step 2: Backfill start_date/end_date for the rows that already exist
+-- (packaging-personified, sweetwater-sound, zimmer-biomet). If any of
+-- these dates don't match what's actually in date_range, double check
+-- with: SELECT slug, date_range FROM portfolio_employers;
+-- ----------------------------------------------------------------------
+UPDATE portfolio_employers SET start_date = '2025-10-01', end_date = NULL         WHERE slug = 'packaging-personified';
+UPDATE portfolio_employers SET start_date = '2021-05-01', end_date = '2025-08-01' WHERE slug = 'sweetwater-sound';
+UPDATE portfolio_employers SET start_date = '2020-10-01', end_date = '2021-05-01' WHERE slug = 'zimmer-biomet';
+
+-- Backfill the short "summary" blurb (shown on homepage preview cards) --
+-- description will keep the existing longer text for the full employer page.
+UPDATE portfolio_employers SET summary = 'Building internal Retool applications for production, compliance, accounting, and operations teams.' WHERE slug = 'packaging-personified';
+UPDATE portfolio_employers SET summary = 'Delivered internal tools, workflow automations, and revenue-driving platforms across accounting, commerce, and merchandising.' WHERE slug = 'sweetwater-sound';
+UPDATE portfolio_employers SET summary = 'Supported device deployment and IT operations across campuses in the Warsaw area.' WHERE slug = 'zimmer-biomet';
+
+-- ----------------------------------------------------------------------
+-- Step 3: Once every existing row has start_date and summary set, make
+-- them required and drop the old free-text date_range column.
+-- ----------------------------------------------------------------------
+ALTER TABLE portfolio_employers
+  MODIFY start_date DATE NOT NULL,
+  MODIFY summary VARCHAR(500) NOT NULL,
+  DROP COLUMN date_range;
+
+-- ----------------------------------------------------------------------
+-- Step 4: Add the two normalized child tables (safe to run any time,
+-- IF NOT EXISTS makes this idempotent).
+-- ----------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS portfolio_employer_highlights (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  employer_id INT NOT NULL,
+  highlight TEXT NOT NULL,
+  sort_order INT DEFAULT 0,
+  FOREIGN KEY (employer_id) REFERENCES portfolio_employers(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS portfolio_employer_case_studies (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  employer_id INT NOT NULL,
+  title VARCHAR(255) NOT NULL,
+  summary TEXT NOT NULL,
+  image VARCHAR(255) DEFAULT NULL,
+  sort_order INT DEFAULT 0,
+  FOREIGN KEY (employer_id) REFERENCES portfolio_employers(id) ON DELETE CASCADE
+);
+
+-- ----------------------------------------------------------------------
+-- Step 5: Add the new employers (Census Bureau, Staples, Black's Concrete
+-- Construction) and seed highlights/case studies for every employer. See
+-- docs/mariadb-setup.sql for the full ready-to-run INSERT statements --
+-- copy the portfolio_employers / portfolio_employer_highlights /
+-- portfolio_employer_case_studies blocks from there. Those INSERTs use
+-- ON DUPLICATE KEY UPDATE for the employer rows, so they're safe to run
+-- even though packaging-personified/sweetwater-sound/zimmer-biomet
+-- already exist.
+-- ----------------------------------------------------------------------

--- a/src/app/blog/[slug]/page.js
+++ b/src/app/blog/[slug]/page.js
@@ -1,8 +1,9 @@
 import Link from "next/link";
-import { getBlogPostBySlug } from "@/lib/portfolio-data";
+import { getBlogPostBySlug, getBlogPosts } from "@/lib/portfolio-data";
 
 export async function generateStaticParams() {
-  return [{ slug: "building-clarity-with-retool" }, { slug: "why-i-still-love-sql" }];
+  const posts = await getBlogPosts();
+  return posts.map((post) => ({ slug: post.slug }));
 }
 
 export default async function BlogPostPage({ params }) {

--- a/src/app/components/PortfolioShell.jsx
+++ b/src/app/components/PortfolioShell.jsx
@@ -2,7 +2,6 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { useState } from "react";
 
 import {
   FaArrowRight,
@@ -11,8 +10,6 @@ import {
   FaGithub,
   FaLinkedin,
   FaPhoneAlt,
-  FaBars,
-  FaTimes,
 } from "react-icons/fa";
 import { SiIndeed } from "react-icons/si";
 
@@ -49,8 +46,7 @@ export default function PortfolioShell({
   aboutBody,
   aboutBullets,
   experienceHeading,
-  experienceHighlights,
-  employerHighlights,
+  employers,
   projectsHeading,
   featuredProjects,
   projectHistory,
@@ -58,64 +54,8 @@ export default function PortfolioShell({
   contactBody,
   contactLinks,
 }) {
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-
   return (
     <main className="min-h-screen bg-slate-950 text-slate-100">
-      <nav className="sticky top-0 z-20 border-b border-white/10 bg-slate-950/80 backdrop-blur">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4 lg:px-8">
-          <Link href="/" className="text-lg font-semibold uppercase tracking-[0.2em] text-white">
-            Ryan Hurd
-          </Link>
-          <div className="hidden items-center gap-4 text-sm text-slate-300 md:flex">
-            <Link href="#about" className="transition hover:text-white">
-              About
-            </Link>
-            <Link href="#experience" className="transition hover:text-white">
-              Experience
-            </Link>
-            <Link href="#projects" className="transition hover:text-white">
-              Work
-            </Link>
-            <Link href="/blog" className="transition hover:text-white">
-              Blog
-            </Link>
-            <Link href="#contact" className="transition hover:text-white">
-              Contact
-            </Link>
-          </div>
-          <button
-            type="button"
-            className="inline-flex items-center justify-center rounded-full border border-white/10 p-2 text-slate-200 md:hidden"
-            onClick={() => setMobileMenuOpen((open) => !open)}
-            aria-label="Toggle menu"
-          >
-            {mobileMenuOpen ? <FaTimes /> : <FaBars />}
-          </button>
-        </div>
-        {mobileMenuOpen && (
-          <div className="border-t border-white/10 px-6 py-4 md:hidden">
-            <div className="flex flex-col gap-3 text-sm text-slate-300">
-              <Link href="#about" className="transition hover:text-white" onClick={() => setMobileMenuOpen(false)}>
-                About
-              </Link>
-              <Link href="#experience" className="transition hover:text-white" onClick={() => setMobileMenuOpen(false)}>
-                Experience
-              </Link>
-              <Link href="#projects" className="transition hover:text-white" onClick={() => setMobileMenuOpen(false)}>
-                Work
-              </Link>
-              <Link href="/blog" className="transition hover:text-white" onClick={() => setMobileMenuOpen(false)}>
-                Blog
-              </Link>
-              <Link href="#contact" className="transition hover:text-white" onClick={() => setMobileMenuOpen(false)}>
-                Contact
-              </Link>
-            </div>
-          </div>
-        )}
-      </nav>
-
       <section id="top" className="mx-auto max-w-6xl px-6 py-20 lg:px-8 lg:py-28">
         <div className="grid items-center gap-16 lg:grid-cols-[1.2fr_0.8fr]">
           <div className="order-2 lg:order-1">
@@ -197,12 +137,12 @@ export default function PortfolioShell({
         </div>
 
         <div className="mt-8 grid gap-6 lg:grid-cols-3">
-          {experienceHighlights.map((item) => (
-            <Link key={item.slug} href={`/experience/${item.slug}`} className="rounded-3xl border border-white/10 bg-slate-900/70 p-6 transition hover:border-sky-400 hover:bg-slate-800/90">
-              <p className="text-sm text-sky-400">{item.date}</p>
-              <h3 className="mt-2 text-xl font-semibold text-white">{item.title}</h3>
-              <p className="mt-1 text-sm text-slate-400">{item.company}</p>
-              <p className="mt-4 text-sm leading-7 text-slate-300">{item.description}</p>
+          {employers.map((employer) => (
+            <Link key={employer.slug} href={`/experience/${employer.slug}`} className="rounded-3xl border border-white/10 bg-slate-900/70 p-6 transition hover:border-sky-400 hover:bg-slate-800/90">
+              <p className="text-sm text-sky-400">{employer.dateRange}</p>
+              <h3 className="mt-2 text-xl font-semibold text-white">{employer.title}</h3>
+              <p className="mt-1 text-sm text-slate-400">{employer.name}</p>
+              <p className="mt-4 text-sm leading-7 text-slate-300">{employer.summary}</p>
             </Link>
           ))}
         </div>

--- a/src/app/components/SiteHeader.jsx
+++ b/src/app/components/SiteHeader.jsx
@@ -1,0 +1,148 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import { FaBars, FaChevronDown, FaTimes } from "react-icons/fa";
+
+const navLinkClass = "transition hover:text-white";
+
+export default function SiteHeader({ employers = [] }) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const [workOpen, setWorkOpen] = useState(false);
+  const [mobileWorkOpen, setMobileWorkOpen] = useState(false);
+  const closeTimer = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimer.current) {
+        clearTimeout(closeTimer.current);
+      }
+    };
+  }, []);
+
+  function openWork() {
+    if (closeTimer.current) {
+      clearTimeout(closeTimer.current);
+    }
+    setWorkOpen(true);
+  }
+
+  function scheduleCloseWork() {
+    closeTimer.current = setTimeout(() => setWorkOpen(false), 150);
+  }
+
+  return (
+    <header className="sticky top-0 z-20 border-b border-white/10 bg-slate-950/80 backdrop-blur">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4 lg:px-8">
+        <Link href="/" className="text-lg font-semibold uppercase tracking-[0.2em] text-white">
+          Ryan Hurd
+        </Link>
+
+        <div className="hidden items-center gap-4 text-sm text-slate-300 md:flex">
+          <Link href="/#about" className={navLinkClass}>
+            About
+          </Link>
+          <Link href="/#experience" className={navLinkClass}>
+            Experience
+          </Link>
+
+          <div className="relative" onMouseEnter={openWork} onMouseLeave={scheduleCloseWork}>
+            <button
+              type="button"
+              className={`flex items-center gap-1 ${navLinkClass}`}
+              aria-haspopup="menu"
+              aria-expanded={workOpen}
+              onClick={() => setWorkOpen((open) => !open)}
+              onFocus={openWork}
+            >
+              Work
+              <FaChevronDown className={`text-xs transition-transform ${workOpen ? "rotate-180" : ""}`} />
+            </button>
+            {workOpen && employers.length > 0 && (
+              <div
+                role="menu"
+                className="absolute left-0 top-full mt-2 w-64 rounded-2xl border border-white/10 bg-slate-900/95 p-2 shadow-xl backdrop-blur"
+                onFocus={openWork}
+                onBlur={scheduleCloseWork}
+              >
+                {employers.map((employer) => (
+                  <Link
+                    key={employer.slug}
+                    href={`/experience/${employer.slug}`}
+                    role="menuitem"
+                    className="block rounded-xl px-3 py-2 text-sm text-slate-300 transition hover:bg-white/5 hover:text-white"
+                    onClick={() => setWorkOpen(false)}
+                  >
+                    {employer.name}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <Link href="/blog" className={navLinkClass}>
+            Blog
+          </Link>
+          <Link href="/#contact" className={navLinkClass}>
+            Contact
+          </Link>
+        </div>
+
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-full border border-white/10 p-2 text-slate-200 md:hidden"
+          onClick={() => setMobileOpen((open) => !open)}
+          aria-label="Toggle menu"
+        >
+          {mobileOpen ? <FaTimes /> : <FaBars />}
+        </button>
+      </div>
+
+      {mobileOpen && (
+        <div className="border-t border-white/10 px-6 py-4 md:hidden">
+          <div className="flex flex-col gap-3 text-sm text-slate-300">
+            <Link href="/#about" className={navLinkClass} onClick={() => setMobileOpen(false)}>
+              About
+            </Link>
+            <Link href="/#experience" className={navLinkClass} onClick={() => setMobileOpen(false)}>
+              Experience
+            </Link>
+
+            <div>
+              <button
+                type="button"
+                className="flex w-full items-center justify-between text-left"
+                aria-expanded={mobileWorkOpen}
+                onClick={() => setMobileWorkOpen((open) => !open)}
+              >
+                Work
+                <FaChevronDown className={`text-xs transition-transform ${mobileWorkOpen ? "rotate-180" : ""}`} />
+              </button>
+              {mobileWorkOpen && (
+                <div className="mt-2 flex flex-col gap-2 border-l border-white/10 pl-4">
+                  {employers.map((employer) => (
+                    <Link
+                      key={employer.slug}
+                      href={`/experience/${employer.slug}`}
+                      className="text-slate-400 transition hover:text-white"
+                      onClick={() => setMobileOpen(false)}
+                    >
+                      {employer.name}
+                    </Link>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <Link href="/blog" className={navLinkClass} onClick={() => setMobileOpen(false)}>
+              Blog
+            </Link>
+            <Link href="/#contact" className={navLinkClass} onClick={() => setMobileOpen(false)}>
+              Contact
+            </Link>
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/src/app/experience/[slug]/page.js
+++ b/src/app/experience/[slug]/page.js
@@ -2,113 +2,16 @@ import Link from "next/link";
 import Image from "next/image";
 import { FaArrowLeft, FaEnvelope, FaFileAlt, FaGithub, FaLinkedin, FaPhoneAlt } from "react-icons/fa";
 import { SiIndeed } from "react-icons/si";
+import { getEmployerBySlug, getEmployers } from "@/lib/portfolio-data";
 
-const employerContent = {
-  "packaging-personified": {
-    name: "Packaging Personified, Inc.",
-    title: "Software Engineer",
-    date: "Oct 2025–Present",
-    location: "Warsaw, IN",
-    heroTitle: "Building practical tools for operations, production, and compliance teams.",
-    heroBody:
-      "At Packaging Personified, I’ve focused on building Retool applications that connect production data, reporting needs, and operational workflows in a way that is fast, usable, and reliable.",
-    intro:
-      "My work has centered on creating internal tools for production, compliance, accounting, and operations groups. I’ve built applications that reduce manual effort, make data more accessible, and improve consistency across teams.",
-    bullets: [
-      "Developed and maintained internal applications using Retool, PostgreSQL, SQL, and JavaScript for production, compliance, accounting, and operations teams.",
-      "Built the Yield Report application to track company and customer job performance, material usage, production efficiency, and operational trends.",
-      "Consolidated spreadsheets and multiple data sources into EPA reporting tools supporting environmental compliance workflows for Illinois and Michigan facilities.",
-      "Created reusable tools, including a standardized Header Module and scalable Location Swap application, to improve consistency across Retool applications.",
-      "Optimized applications and automated workflows for performance, reliability, and usability, including improving Press WIP processing speed by more than 40%.",
-      "Trained managers, developers, company owners, and end users on Retool functionality, application workflows, and development best practices.",
-    ],
-    projects: [
-      {
-        title: "Yield Report",
-        summary:
-          "A reporting tool for tracking production and customer performance trends using operational data from multiple sources.",
-        image: "/images/projects/ppi-yield-report.svg",
-      },
-      {
-        title: "EPA Reporting",
-        summary:
-          "A compliance-oriented reporting workflow that combines spreadsheets and source data into a more maintainable reporting experience.",
-        image: "/images/projects/ppi-epa-reporting.svg",
-      },
-      {
-        title: "Press WIP Optimization",
-        summary:
-          "A performance-focused workflow improvement project that reduced processing time and simplified day-to-day operations.",
-        image: "/images/projects/ppi-press-wip.svg",
-      },
-    ],
-  },
-  sweetwater: {
-    name: "Sweetwater Sound",
-    title: "Software Engineer",
-    date: "May 2021–Aug 2025",
-    location: "Fort Wayne, IN",
-    heroTitle: "Creating tools that support teams across operations, support, and customer experience.",
-    heroBody:
-      "At Sweetwater, I worked across multiple engineering pods and learned how to deliver solutions that balanced speed, reliability, and a strong user experience.",
-    intro:
-      "My work spanned several internal initiatives that improved business workflows, supported teams in daily operations, and helped modernize internal tooling.",
-    bullets: [
-      "Built and maintained Retool applications that served internal teams and business operations.",
-      "Worked on accounting, compliance, and customer-facing workflow functionality in a fast-moving environment.",
-      "Developed features that improved reliability and streamlined everyday task completion.",
-      "Partnered with teammates to solve practical problems with thoughtful, maintainable software.",
-    ],
-    projects: [
-      {
-        title: "Turkey Handout App",
-        summary: "A fast-turnaround internal tool that made holiday employee gifting easier and more organized.",
-        image: "/images/projects/1.png",
-      },
-      {
-        title: "Gear Exchange",
-        summary: "Helped support commerce workflows and secure payment integration for a rapidly growing platform.",
-        image: "/images/projects/2.jpg",
-      },
-      {
-        title: "DementiaTrack",
-        summary: "A capstone project that combined thoughtful software design with practical analytics.",
-        image: "/images/projects/9.jpg",
-      },
-    ],
-  },
-  "zimmer-biomet": {
-    name: "Zimmer Biomet",
-    title: "IT Intern",
-    date: "2020–2021",
-    location: "Warsaw, IN",
-    heroTitle: "Learning dependable systems and operational support in a hands-on environment.",
-    heroBody:
-      "During my internship, I supported device deployment and IT operations while building a strong foundation in reliable systems and teamwork.",
-    intro:
-      "This role helped me grow in practical problem solving, structured workflows, and the importance of dependable support work behind the scenes.",
-    bullets: [
-      "Prepared and deployed company devices for use across the organization.",
-      "Supported inventory, configuration, and delivery workflows.",
-      "Learned how careful systems work and good operational support improve team productivity.",
-    ],
-    projects: [
-      {
-        title: "Device Deployment Support",
-        summary: "Helped prepare and configure systems for company use in a structured, detail-focused workflow.",
-        image: "/images/projects/zimmer-biomet.jpg",
-      },
-    ],
-  },
-};
-
-export function generateStaticParams() {
-  return [{ slug: "packaging-personified" }, { slug: "sweetwater" }, { slug: "zimmer-biomet" }];
+export async function generateStaticParams() {
+  const employers = await getEmployers();
+  return employers.map((employer) => ({ slug: employer.slug }));
 }
 
-export default function EmployerPage({ params }) {
-  const { slug } = params;
-  const employer = employerContent[slug];
+export default async function EmployerPage({ params }) {
+  const { slug } = await params;
+  const employer = await getEmployerBySlug(slug);
 
   if (!employer) {
     return (
@@ -135,64 +38,51 @@ export default function EmployerPage({ params }) {
 
   return (
     <main className="min-h-screen bg-slate-950 text-slate-100">
-      <nav className="sticky top-0 z-20 border-b border-white/10 bg-slate-950/80 backdrop-blur">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4 lg:px-8">
-          <Link href="/" className="text-lg font-semibold uppercase tracking-[0.2em] text-white">
-            Ryan Hurd
-          </Link>
-          <Link href="/" className="text-sm text-slate-300 transition hover:text-white">
-            Back home
-          </Link>
-        </div>
-      </nav>
-
       <section className="mx-auto max-w-6xl px-6 py-20 lg:px-8">
         <div className="rounded-3xl border border-white/10 bg-slate-900/70 p-8 lg:p-10">
-          <div className="grid gap-8 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
-            <div>
-              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-sky-400">Experience</p>
-              <h1 className="mt-3 text-4xl font-semibold text-white">{employer.name}</h1>
-              <p className="mt-3 text-lg text-slate-300">{employer.title} • {employer.date}</p>
-              <p className="mt-2 text-sm text-slate-400">{employer.location}</p>
-              <p className="mt-6 text-lg text-slate-300">{employer.heroBody}</p>
-            </div>
-            <div className="overflow-hidden rounded-2xl border border-white/10">
-              <Image src={employer.image || "/images/ryan_pfp.png"} alt={employer.name} width={1200} height={900} className="h-full w-full object-cover" />
-            </div>
-          </div>
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-sky-400">Experience</p>
+          <h1 className="mt-3 text-4xl font-semibold text-white">{employer.name}</h1>
+          <p className="mt-3 text-lg text-slate-300">
+            {employer.title} • {employer.dateRange}
+          </p>
+          <p className="mt-2 text-sm text-slate-400">{employer.location}</p>
+          <p className="mt-6 text-lg text-slate-300">{employer.description}</p>
         </div>
       </section>
 
-      <section className="mx-auto max-w-6xl px-6 py-8 lg:px-8">
-        <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-8 lg:p-10">
-          <h2 className="text-3xl font-semibold text-white">What I worked on</h2>
-          <p className="mt-4 text-lg text-slate-300">{employer.intro}</p>
-          <ul className="mt-6 space-y-3 text-sm leading-7 text-slate-300">
-            {employer.bullets.map((bullet) => (
-              <li key={bullet}>• {bullet}</li>
-            ))}
-          </ul>
-        </div>
-      </section>
-
-      <section className="mx-auto max-w-6xl px-6 py-8 lg:px-8">
-        <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-8 lg:p-10">
-          <h2 className="text-3xl font-semibold text-white">Featured work</h2>
-          <div className="mt-8 grid gap-6 lg:grid-cols-3">
-            {employer.projects.map((project) => (
-              <article key={project.title} className="overflow-hidden rounded-3xl border border-white/10 bg-slate-950/70">
-                <div className="relative h-48 w-full">
-                  <Image src={project.image} alt={project.title} fill className="object-cover" />
-                </div>
-                <div className="p-6">
-                  <h3 className="text-xl font-semibold text-white">{project.title}</h3>
-                  <p className="mt-3 text-sm leading-7 text-slate-300">{project.summary}</p>
-                </div>
-              </article>
-            ))}
+      {employer.highlights?.length > 0 && (
+        <section className="mx-auto max-w-6xl px-6 py-8 lg:px-8">
+          <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-8 lg:p-10">
+            <h2 className="text-3xl font-semibold text-white">What I worked on</h2>
+            <ul className="mt-6 space-y-3 text-sm leading-7 text-slate-300">
+              {employer.highlights.map((highlight) => (
+                <li key={highlight}>• {highlight}</li>
+              ))}
+            </ul>
           </div>
-        </div>
-      </section>
+        </section>
+      )}
+
+      {employer.caseStudies?.length > 0 && (
+        <section className="mx-auto max-w-6xl px-6 py-8 lg:px-8">
+          <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-8 lg:p-10">
+            <h2 className="text-3xl font-semibold text-white">Featured work</h2>
+            <div className="mt-8 grid gap-6 lg:grid-cols-3">
+              {employer.caseStudies.map((project) => (
+                <article key={project.title} className="overflow-hidden rounded-3xl border border-white/10 bg-slate-950/70">
+                  <div className="relative h-48 w-full">
+                    <Image src={project.image} alt={project.title} fill className="object-cover" />
+                  </div>
+                  <div className="p-6">
+                    <h3 className="text-xl font-semibold text-white">{project.title}</h3>
+                    <p className="mt-3 text-sm leading-7 text-slate-300">{project.summary}</p>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
 
       <section className="mx-auto max-w-6xl px-6 py-16 lg:px-8">
         <div className="rounded-3xl border border-sky-500/20 bg-gradient-to-br from-slate-900 to-slate-950 p-8 lg:p-10">

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,5 +1,7 @@
 import localFont from "next/font/local";
 import "./globals.css";
+import SiteHeader from "./components/SiteHeader";
+import { getEmployers } from "@/lib/portfolio-data";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -18,10 +20,13 @@ export const metadata = {
     "Portfolio site for Ryan Hurd, a software engineer focused on thoughtful tools and practical solutions.",
 };
 
-export default function RootLayout({ children }) {
+export default async function RootLayout({ children }) {
+  const employers = await getEmployers();
+
   return (
     <html lang="en" className="scroll-smooth">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <SiteHeader employers={employers} />
         {children}
       </body>
     </html>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,5 +1,5 @@
 import PortfolioShell from "./components/PortfolioShell";
-import { getHomepageData } from "@/lib/portfolio-data";
+import { getEmployers, getHomepageData } from "@/lib/portfolio-data";
 
 const contactLinks = [
   {
@@ -35,7 +35,7 @@ const contactLinks = [
 ];
 
 export default async function Home() {
-  const homeData = await getHomepageData();
+  const [homeData, employers] = await Promise.all([getHomepageData(), getEmployers()]);
 
   return (
     <PortfolioShell
@@ -49,8 +49,7 @@ export default async function Home() {
       aboutBody={homeData.aboutBody}
       aboutBullets={homeData.aboutBullets}
       experienceHeading={homeData.experienceHeading}
-      experienceHighlights={homeData.experienceHighlights}
-      employerHighlights={homeData.employerHighlights}
+      employers={employers.slice(0, 3)}
       projectsHeading={homeData.projectsHeading}
       featuredProjects={homeData.featuredProjects}
       projectHistory={homeData.projectHistory}

--- a/src/lib/portfolio-data.js
+++ b/src/lib/portfolio-data.js
@@ -22,33 +22,7 @@ const fallbackHomeData = {
   ],
   experienceHeading:
     "Experience that spans engineering, operations, and teamwork.",
-  experienceHighlights: [
-    {
-      title: "Software Engineer",
-      company: "Packaging Personified, Inc.",
-      date: "Oct 2025–Present",
-      slug: "packaging-personified",
-      description:
-        "Building internal applications and operational tools for production, compliance, accounting, and leadership teams using Retool, PostgreSQL, SQL, and JavaScript.",
-    },
-    {
-      title: "Software Engineer",
-      company: "Sweetwater Sound",
-      date: "May 2021–Aug 2025",
-      slug: "sweetwater",
-      description:
-        "Delivered internal tools, workflow automations, and user-focused applications across support, accounting, customer experience, and Retool teams.",
-    },
-    {
-      title: "IT Intern",
-      company: "Zimmer Biomet",
-      date: "2020–2021",
-      slug: "zimmer-biomet",
-      description:
-        "Supported device deployment and IT operations while building a practical foundation in reliable systems and collaboration.",
-    },
-  ],
-  projectsHeading: "Some of my favorite projects.",
+  projectsHeading: "Some of my projects.",
   featuredProjects: [
     {
       title: "Yield Report",
@@ -94,26 +68,6 @@ const fallbackHomeData = {
     "Kiosk Manager",
   ],
 
-  employerHighlights: [
-    {
-      title: "Packaging Personified",
-      blurb:
-        "Operations, compliance, and production tooling in a fast-moving manufacturing environment.",
-      slug: "packaging-personified",
-    },
-    {
-      title: "Sweetwater",
-      blurb:
-        "Cross-functional internal tools for support, accounting, and customer experience teams.",
-      slug: "sweetwater",
-    },
-    {
-      title: "Zimmer Biomet",
-      blurb:
-        "A grounded start in IT operations and dependable systems support.",
-      slug: "zimmer-biomet",
-    },
-  ],
   contactHeading: "Open to thoughtful opportunities and conversations.",
   contactBody:
     "If you are looking for someone who can bring calm execution, strong communication, and practical problem solving to a team, I would love to hear from you.",
@@ -147,31 +101,159 @@ const fallbackEmployers = [
     slug: "packaging-personified",
     name: "Packaging Personified, Inc.",
     title: "Software Engineer",
-    dateRange: "Oct 2025 - Current",
-    location: "Remote",
+    startDate: "2025-10-01",
+    endDate: null,
+    location: "Warsaw, IN",
+    summary:
+      "Building internal Retool applications for production, compliance, accounting, and operations teams.",
     description:
-      "At Packaging Personified, I’ve focused on building Retool applications that connect production data, reporting needs, and operational workflows in a way that is fast, usable, and reliable.",
+      "Building internal Retool applications for production, compliance, accounting, and operations teams, including a Yield Report tool for tracking job performance and material usage, and consolidated EPA reporting for Illinois and Michigan compliance. Created reusable shared modules and delivered a 40%+ performance improvement to the Press WIP application while training managers and end users on Retool best practices.",
     sortOrder: 1,
+    highlights: [
+      "Developed and maintained internal applications using Retool, PostgreSQL, SQL, and JavaScript for production, compliance, accounting, and operations teams.",
+      "Built the Yield Report application to track company and customer job performance, material usage, production efficiency, and operational trends.",
+      "Consolidated spreadsheets and multiple data sources into EPA reporting tools supporting environmental compliance workflows for Illinois and Michigan facilities.",
+      "Created reusable tools, including a standardized Header Module and scalable Location Swap application, to improve consistency across Retool applications.",
+      "Optimized applications and automated workflows for performance, reliability, and usability, including improving Press WIP processing speed by more than 40%.",
+      "Trained managers, developers, company owners, and end users on Retool functionality, application workflows, and development best practices.",
+    ],
+    caseStudies: [
+      {
+        title: "Yield Report",
+        summary:
+          "A reporting tool for tracking production and customer performance trends using operational data from multiple sources.",
+        image: "/images/projects/ppi-yield-report.svg",
+      },
+      {
+        title: "EPA Reporting",
+        summary:
+          "A compliance-oriented reporting workflow that combines spreadsheets and source data into a more maintainable reporting experience.",
+        image: "/images/projects/ppi-epa-reporting.svg",
+      },
+      {
+        title: "Press WIP Optimization",
+        summary:
+          "A performance-focused workflow improvement project that reduced processing time and simplified day-to-day operations.",
+        image: "/images/projects/ppi-press-wip.svg",
+      },
+    ],
   },
   {
     slug: "sweetwater-sound",
     name: "Sweetwater Sound",
     title: "Software Engineer",
-    dateRange: "May 2021 - Aug 2025",
+    startDate: "2021-05-01",
+    endDate: "2025-08-01",
     location: "Fort Wayne, IN",
+    summary:
+      "Delivered internal tools, workflow automations, and revenue-driving platforms across accounting, commerce, and merchandising.",
     description:
-      "At Sweetwater, I worked across multiple engineering pods and learned how to deliver solutions that balanced speed, reliability, and a strong user experience.",
+      "Sole developer of Avalara's Exemption Certificate Management System, saving the tax team 160+ hours of manual validation per month, and integrated PayPal's Braintree system into the CRM to help launch Gear Exchange, which generated over $1M in sales within months. Also built a dynamic Price Management Platform that drove $4M in revenue in under a month, alongside daily-use internal tools across departments.",
     sortOrder: 2,
+    highlights: [
+      "Sole developer on the implementation of Avalara's Exemption Certificate Management System (ECMS), saving the tax team the equivalent of 160+ hours of validating exemption certificates per month.",
+      "Integrated PayPal's GraphQL-based Braintree system into the CRM to help launch Gear Exchange, which saw over $1M in sales between users within its first few months.",
+      "Built and deployed a Price Management Platform used by merchandising to adjust pricing dynamically, resulting in $4M in increased revenue in under a month.",
+      "Provided a Turkey Handout application for Sweetwater's Thanksgiving giveaway within 72 hours, allowing the campus events team to hand out turkeys and gift cards to 2,500 employees.",
+      "Contributed to internal software development by designing scalable features, debugging production issues, and delivering tools used daily across multiple departments.",
+    ],
+    caseStudies: [
+      {
+        title: "Turkey Handout App",
+        summary: "A fast-turnaround internal tool that made holiday employee gifting easier and more organized.",
+        image: "/images/projects/1.png",
+      },
+      {
+        title: "Gear Exchange",
+        summary: "Helped support commerce workflows and secure payment integration for a rapidly growing platform.",
+        image: "/images/projects/2.jpg",
+      },
+      {
+        title: "DementiaTrack",
+        summary: "A capstone project that combined thoughtful software design with practical analytics.",
+        image: "/images/projects/9.jpg",
+      },
+    ],
   },
   {
     slug: "zimmer-biomet",
     name: "Zimmer Biomet",
-    title: "IT Intern",
-    dateRange: "Oct 2020 - Aug 2021",
-    location: "Fort Wayne, IN",
+    title: "Information Technology Intern",
+    startDate: "2020-10-01",
+    endDate: "2021-05-01",
+    location: "Warsaw, IN",
+    summary: "Supported device deployment and IT operations across campuses in the Warsaw area.",
     description:
-      "During my internship, I supported device deployment and IT operations while building a strong foundation in reliable systems and teamwork.",
+      "Imaged and deployed company devices, issued laptops and accessories, and performed hardware upgrades for onboarding and refresh cycles. Delivered devices to campuses across the Warsaw area as part of IT operations support.",
     sortOrder: 3,
+    highlights: [
+      "Imaged and prepared company devices with software for deployment.",
+      "Issued laptops, accessories, and performed hardware upgrades for onboarding and refreshing hardware.",
+      "Used a company vehicle to deliver devices to various campuses in the Warsaw area.",
+    ],
+    caseStudies: [
+      {
+        title: "Device Deployment Support",
+        summary: "Helped prepare and configure systems for company use in a structured, detail-focused workflow.",
+        image: "/images/projects/zimmer-biomet.jpg",
+      },
+    ],
+  },
+  {
+    slug: "census-bureau",
+    name: "United States Census Bureau",
+    title: "Post-Enumeration Surveyor",
+    startDate: "2020-01-01",
+    endDate: "2020-10-01",
+    location: "Warsaw, IN",
+    summary: "Collected population data door-to-door for the U.S. Census Bureau's Post-Enumeration Survey.",
+    description:
+      "Conducted in-person interviews to collect population data for the Post-Enumeration Survey, ensuring census accuracy while complying with strict federal confidentiality guidelines. Maintained detailed activity logs and navigated difficult resident interactions with calm, professional de-escalation.",
+    sortOrder: 4,
+    highlights: [
+      "Performed interviews at addresses within assigned blocks to collect population data as part of the Post-Enumeration Survey, ensuring census accuracy.",
+      "Complied with strict federal guidelines and confidentiality rules for gathering demographic and housing information.",
+      "Recorded information using a government-issued laptop, maintaining hour logs, mileage, and case activity.",
+      "Navigated difficult or uncooperative situations by calmly diffusing tensions with hesitant or hostile residents.",
+    ],
+    caseStudies: [],
+  },
+  {
+    slug: "staples",
+    name: "Staples",
+    title: "Technology Sales Associate",
+    startDate: "2018-06-01",
+    endDate: "2019-05-01",
+    location: "Warsaw, IN",
+    summary: "Helped customers find the right technology products as a top-performing sales associate.",
+    description:
+      "Assessed customer needs and guided them to the right technology products, consistently ranking as the top store in Northern Indiana for several consecutive weeks. Stayed current on promotions and product launches to support sales goals.",
+    sortOrder: 5,
+    highlights: [
+      "Asked customers pertinent questions to assess and determine their needs, guiding them to the correct product.",
+      "Answered questions, explained product features, and gave honest input based on customer needs.",
+      "Used Staples sales strategies to become the number one store in Northern Indiana for several weeks straight.",
+      "Stayed up to date on weekly promotions and product launches to best support customers and hit sales goals.",
+    ],
+    caseStudies: [],
+  },
+  {
+    slug: "blacks-concrete-construction",
+    name: "Black's Concrete Construction",
+    title: "Concrete Laborer",
+    startDate: "2016-06-01",
+    endDate: "2017-03-01",
+    location: "Warsaw, IN",
+    summary: "Handled nearly every phase of residential concrete work on a small, hands-on crew.",
+    description:
+      "Worked as part of a small 2-3 person crew handling nearly every phase of residential concrete work, including driving the company truck, forming, pouring, finishing, cutting, cleaning, sealing, and stamping. Gained hands-on versatility and a strong work ethic from taking on broad responsibility within a lean, close-knit team.",
+    sortOrder: 6,
+    highlights: [
+      "Drove the company truck and handled nearly every phase of residential concrete work on a lean 2-3 person crew.",
+      "Performed forming, pouring, finishing, cutting, cleaning, sealing, and stamping across a wide range of jobs.",
+      "Gained hands-on versatility and a strong work ethic from taking on broad responsibility within a small, close-knit team.",
+    ],
+    caseStudies: [],
   },
 ];
 
@@ -214,6 +296,39 @@ async function getDatabaseConnection() {
 
 function normalizeDate(value) {
   return value instanceof Date ? value.toISOString().slice(0, 10) : value;
+}
+
+function formatMonthYear(value) {
+  if (!value) {
+    return null;
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  return date.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+}
+
+function formatDateRange(startDate, endDate) {
+  const start = formatMonthYear(startDate);
+  if (!start) {
+    return null;
+  }
+
+  return `${start} – ${endDate ? formatMonthYear(endDate) : "Present"}`;
+}
+
+function normalizeEmployerRow(row) {
+  return {
+    slug: row.slug,
+    name: row.name,
+    title: row.title,
+    startDate: normalizeDate(row.start_date ?? row.startDate),
+    endDate: normalizeDate(row.end_date ?? row.endDate),
+    dateRange: formatDateRange(row.start_date ?? row.startDate, row.end_date ?? row.endDate),
+    location: row.location,
+    summary: row.summary,
+    description: row.description,
+    sortOrder: row.sort_order ?? row.sortOrder,
+  };
 }
 
 function normalizeImagePath(image) {
@@ -373,29 +488,71 @@ export async function getEmployers() {
   const connection = await getDatabaseConnection();
 
   if (!connection) {
-    return fallbackEmployers;
+    return fallbackEmployers.map(normalizeEmployerRow);
   }
 
   try {
     const [rows] = await connection.query(
-      "SELECT slug, name, title, date_range, location, description, sort_order FROM portfolio_employers",
+      "SELECT slug, name, title, start_date, end_date, location, summary, description, sort_order FROM portfolio_employers ORDER BY sort_order ASC",
     );
 
     if (!rows?.length) {
-      return fallbackEmployers;
+      return fallbackEmployers.map(normalizeEmployerRow);
     }
 
-    return rows.map((row) => ({
-      slug: row.slug,
-      name: row.name,
-      title: row.title,
-      dateRange: row.date_range,
-      location: row.location,
-      description: row.description,
-      sortOrder: row.sort_order,
-    }));
-  } catch {
-    return fallbackEmployers;
+    return rows.map(normalizeEmployerRow);
+  } catch (err) {
+    console.error(`Employer query failed: ${err.code || ""} ${err.message}`);
+    return fallbackEmployers.map(normalizeEmployerRow);
+  } finally {
+    await connection.end();
+  }
+}
+
+export async function getEmployerBySlug(slug) {
+  const connection = await getDatabaseConnection();
+
+  if (!connection) {
+    const fallback = fallbackEmployers.find((employer) => employer.slug === slug);
+    return fallback ? { ...normalizeEmployerRow(fallback), highlights: fallback.highlights, caseStudies: fallback.caseStudies } : null;
+  }
+
+  try {
+    const [rows] = await connection.query(
+      "SELECT id, slug, name, title, start_date, end_date, location, summary, description FROM portfolio_employers WHERE slug = ? LIMIT 1",
+      [slug],
+    );
+
+    if (!rows?.length) {
+      const fallback = fallbackEmployers.find((employer) => employer.slug === slug);
+      return fallback ? { ...normalizeEmployerRow(fallback), highlights: fallback.highlights, caseStudies: fallback.caseStudies } : null;
+    }
+
+    const [row] = rows;
+
+    const [highlightRows] = await connection.query(
+      "SELECT highlight FROM portfolio_employer_highlights WHERE employer_id = ? ORDER BY sort_order ASC",
+      [row.id],
+    );
+
+    const [caseStudyRows] = await connection.query(
+      "SELECT title, summary, image FROM portfolio_employer_case_studies WHERE employer_id = ? ORDER BY sort_order ASC",
+      [row.id],
+    );
+
+    return {
+      ...normalizeEmployerRow(row),
+      highlights: highlightRows.map((highlightRow) => highlightRow.highlight),
+      caseStudies: caseStudyRows.map((caseStudyRow) => ({
+        title: caseStudyRow.title,
+        summary: caseStudyRow.summary,
+        image: normalizeImagePath(caseStudyRow.image),
+      })),
+    };
+  } catch (err) {
+    console.error(`Employer query failed: ${err.code || ""} ${err.message}`);
+    const fallback = fallbackEmployers.find((employer) => employer.slug === slug);
+    return fallback ? { ...normalizeEmployerRow(fallback), highlights: fallback.highlights, caseStudies: fallback.caseStudies } : null;
   } finally {
     await connection.end();
   }


### PR DESCRIPTION
…nt header

Fixes "Employer not found": experience/[slug]/page.js had a fully hardcoded employer list and generateStaticParams, completely disconnected from portfolio_employers, so DB rows (e.g. Black's Concrete Construction) could never get a working page. Both experience/[slug] and blog/[slug] now derive their static params from the DB via getEmployers()/getBlogPosts().

Normalizes the employer schema: date_range (free text) becomes real start_date/end_date columns, and two child tables
(portfolio_employer_highlights, portfolio_employer_case_studies) replace what used to be a hardcoded JS object. Adds summary (short, for card previews) alongside description (long, for the employer's own page). See docs/migrations/001_normalize_employers.sql for the guided migration and docs/mariadb-setup.sql for full seed data.

Also extracts the nav into a shared SiteHeader mounted in the root layout (previously only rendered on the homepage, so it disappeared on every other route), and replaces the old "Work" anchor link with an accessible Work dropdown listing employers pulled live from getEmployers().

The homepage's Experience section and header dropdown are now both driven by portfolio_employers directly, replacing the old separate portfolio_content.experienceHighlights/employerHighlights JSON blobs (dead code removed).