### PR TITLE
Color-code Project History chips by company

### DIFF
--- a/src/app/components/PortfolioShell.jsx
+++ b/src/app/components/PortfolioShell.jsx
@@ -53,7 +53,7 @@ export default function PortfolioShell({
   employerHighlights,
   projectsHeading,
   featuredProjects,
-  projectHistory,
+  projects,
   contactHeading,
   contactBody,
   contactLinks,
@@ -245,9 +245,13 @@ export default function PortfolioShell({
             A broad set of projects across operations, finance, commerce, and internal tools.
           </h3>
           <div className="mt-6 flex flex-wrap gap-3">
-            {projectHistory.map((item) => (
-              <span key={item} className="rounded-full border border-white/10 bg-slate-950/70 px-3 py-2 text-sm text-slate-300">
-                {item}
+            {projects.map((project) => (
+              <span
+                key={project.id}
+                title={project.company}
+                className={`rounded-full border px-3 py-2 text-sm ${getProjectChipClass(project.color)}`}
+              >
+                {project.title}
               </span>
             ))}
           </div>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,5 +1,5 @@
 import PortfolioShell from "./components/PortfolioShell";
-import { getHomepageData } from "@/lib/portfolio-data";
+import { getHomepageData, getProjectList } from "@/lib/portfolio-data";
 
 const contactLinks = [
   {
@@ -35,7 +35,7 @@ const contactLinks = [
 ];
 
 export default async function Home() {
-  const homeData = await getHomepageData();
+  const [homeData, projects] = await Promise.all([getHomepageData(), getProjectList()]);
 
   return (
     <PortfolioShell
@@ -53,7 +53,7 @@ export default async function Home() {
       employerHighlights={homeData.employerHighlights}
       projectsHeading={homeData.projectsHeading}
       featuredProjects={homeData.featuredProjects}
-      projectHistory={homeData.projectHistory}
+      projects={projects}
       contactHeading={homeData.contactHeading}
       contactBody={homeData.contactBody}
       contactLinks={contactLinks}

--- a/src/lib/portfolio-data.js
+++ b/src/lib/portfolio-data.js
@@ -69,31 +69,6 @@ const fallbackHomeData = {
       image: "/images/projects/ppi-press-wip.svg",
     },
   ],
-  projectHistory: [
-    "Donut Duty",
-    "Synchrony Bonus Bucks promotions",
-    "Bonus Bucks GUI",
-    "ECMS tax certificate expiration workflow",
-    "Marketplace payments cancellation handling",
-    "Automated collection letters",
-    "Stop UT/CA auto-processing",
-    "Electronic delivery invoice splitting",
-    "CRM performance improvements",
-    "Press release admin tool",
-    "Merchandising price comparison report",
-    "Web text editor",
-    "Make Offer Tool",
-    "404 admin tool",
-    "Retool termination script",
-    "Usability Retool App",
-    "FileMaker purchase order and quote tooling",
-    "XChange management platform",
-    "Store SEO content management",
-    "Sales Engineer planning workspace",
-    "Drumfest check-in scanner workflow",
-    "Kiosk Manager",
-  ],
-
   employerHighlights: [
     {
       title: "Packaging Personified",
@@ -274,9 +249,6 @@ export async function getHomepageData() {
       featuredProjects: normalizeProjectRows(
         projectRows?.length ? projectRows : fallbackHomeData.featuredProjects,
       ),
-      projectHistory: Array.isArray(parsedRows.projectHistory)
-        ? parsedRows.projectHistory
-        : fallbackHomeData.projectHistory,
     };
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
The Project History section rendered projectHistory, a flat array of plain strings with no company association, so there was no way to color it by employer. portfolio_projects already stores company/ company_slug/color per row (used for the Featured Projects cards), so this switches Project History to render getProjectList() instead, reusing the existing getProjectChipClass(color) helper. The company name shows as a title tooltip on hover.

Drops the now-superseded projectHistory field from portfolio_content/fallbackHomeData.