### PR TITLE
Add a "Try it live" section with an embedded Retool Minesweeper app

### DIFF
--- a/src/app/components/PortfolioShell.jsx
+++ b/src/app/components/PortfolioShell.jsx
@@ -4,6 +4,8 @@ import Image from "next/image";
 import Link from "next/link";
 import { useState } from "react";
 
+import RetoolEmbed from "./RetoolEmbed";
+
 import {
   FaArrowRight,
   FaEnvelope,
@@ -234,6 +236,22 @@ export default function PortfolioShell({
                 </div>
               </article>
             ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-6xl px-6 py-8 lg:px-8">
+        <div className="rounded-3xl border border-white/10 bg-slate-900/60 p-8 lg:p-10">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-sky-400">Try it live</p>
+          <h3 className="mt-2 text-2xl font-semibold text-white">
+            Interactive Retool apps you can try right now.
+          </h3>
+          <div className="mt-8 grid gap-6 lg:grid-cols-2">
+            <RetoolEmbed
+              title="Minesweeper"
+              description="A classic Minesweeper build in Retool, showing off custom component logic and state management."
+              src="https://rh25170.retool.com/embedded/public/3098f072-da08-4876-b3aa-0f14f020ea8a"
+            />
           </div>
         </div>
       </section>

--- a/src/app/components/RetoolEmbed.jsx
+++ b/src/app/components/RetoolEmbed.jsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useState } from "react";
+
+export default function RetoolEmbed({ title, description, src }) {
+  const [loaded, setLoaded] = useState(false);
+
+  return (
+    <div className="overflow-hidden rounded-3xl border border-white/10 bg-slate-950/70">
+      <div className="p-6">
+        <h3 className="text-xl font-semibold text-white">{title}</h3>
+        <p className="mt-3 text-sm leading-7 text-slate-300">{description}</p>
+        {!loaded && (
+          <button
+            type="button"
+            onClick={() => setLoaded(true)}
+            className="mt-4 inline-flex items-center gap-2 rounded-full bg-sky-500 px-5 py-3 text-sm font-medium text-slate-950 transition hover:bg-sky-400"
+          >
+            Launch app
+          </button>
+        )}
+      </div>
+      {loaded && (
+        <iframe
+          src={src}
+          title={title}
+          width="100%"
+          height="800"
+          loading="lazy"
+          className="block border-0"
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Adds a click-to-load iframe embed (RetoolEmbed.jsx) so the Retool app and its JS don't load until a visitor opts in. Placed after Projects, before Project History.

The debt reduction calculator isn't included yet -- it needs its Retool query swapped from a live personal-finance table to hardcoded demo values before it's safe to make public.