### PR TITLE
Add Education and Certifications sections

### DIFF
--- a/docs/mariadb-setup.sql
+++ b/docs/mariadb-setup.sql
@@ -76,6 +76,31 @@ CREATE TABLE IF NOT EXISTS portfolio_employer_case_studies (
   FOREIGN KEY (employer_id) REFERENCES portfolio_employers(id) ON DELETE CASCADE
 );
 
+-- Standalone from portfolio_employers -- a degree isn't a job, so it gets
+-- its own homepage section rather than being folded into Experience.
+CREATE TABLE IF NOT EXISTS portfolio_education (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  slug VARCHAR(150) NOT NULL UNIQUE,
+  institution VARCHAR(255) NOT NULL,
+  degree VARCHAR(255) DEFAULT NULL,
+  start_date DATE NOT NULL,
+  end_date DATE NULL,
+  location VARCHAR(150) DEFAULT NULL,
+  sort_order INT DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS portfolio_certifications (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  slug VARCHAR(150) NOT NULL UNIQUE,
+  name VARCHAR(255) NOT NULL,
+  issuer VARCHAR(255) DEFAULT NULL,
+  date_earned DATE NULL,
+  credential_url VARCHAR(500) DEFAULT NULL,
+  sort_order INT DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
 INSERT INTO portfolio_content (scope, `key`, `value`, sort_order) VALUES
 ('homepage', 'heroEyebrow', '"Family-first • software engineer • builder"', 1),
 ('homepage', 'heroTitle', '"I build practical internal tools that make teams faster, clearer, and more confident."', 2),
@@ -198,3 +223,12 @@ JOIN (
   UNION ALL SELECT 'sweetwater-sound', 'DementiaTrack', 'A capstone project that combined thoughtful software design with practical analytics.', '/images/projects/9.jpg', 3
   UNION ALL SELECT 'zimmer-biomet', 'Device Deployment Support', 'Helped prepare and configure systems for company use in a structured, detail-focused workflow.', '/images/projects/zimmer-biomet.jpg', 1
 ) c ON c.slug = e.slug;
+INSERT INTO portfolio_education (slug, institution, degree, start_date, end_date, location, sort_order) VALUES
+('whitko', 'Whitko Community High School', 'High School Diploma', '2011-08-01', '2016-05-01', 'South Whitley, IN', 1),
+('ivy-tech', 'Ivy Tech Community College', 'Associate of Science, Computer Science', '2017-01-01', '2019-05-01', 'Warsaw/Fort Wayne, IN', 2),
+('purdue-fort-wayne', 'Purdue University Fort Wayne', 'Bachelor of Science, Computer Science', '2019-08-01', '2021-05-01', 'Fort Wayne, IN', 3)
+ON DUPLICATE KEY UPDATE institution = VALUES(institution), degree = VALUES(degree), start_date = VALUES(start_date), end_date = VALUES(end_date), location = VALUES(location), sort_order = VALUES(sort_order);
+
+INSERT INTO portfolio_certifications (slug, name, issuer, date_earned, credential_url, sort_order) VALUES
+('python-pcep', 'Python PCEP Certification', 'Python Institute', '2021-09-01', NULL, 1)
+ON DUPLICATE KEY UPDATE name = VALUES(name), issuer = VALUES(issuer), date_earned = VALUES(date_earned), credential_url = VALUES(credential_url), sort_order = VALUES(sort_order);

--- a/docs/migrations/004_add_education_and_certifications.sql
+++ b/docs/migrations/004_add_education_and_certifications.sql
@@ -1,0 +1,27 @@
+-- Adds Education and Certifications as their own tables (recommended over
+-- folding into portfolio_employers, since a degree isn't a job -- different
+-- fields, no "job title", etc). See docs/mariadb-setup.sql for full seed
+-- data.
+
+CREATE TABLE IF NOT EXISTS portfolio_education (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  slug VARCHAR(150) NOT NULL UNIQUE,
+  institution VARCHAR(255) NOT NULL,
+  degree VARCHAR(255) DEFAULT NULL,
+  start_date DATE NOT NULL,
+  end_date DATE NULL,
+  location VARCHAR(150) DEFAULT NULL,
+  sort_order INT DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS portfolio_certifications (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  slug VARCHAR(150) NOT NULL UNIQUE,
+  name VARCHAR(255) NOT NULL,
+  issuer VARCHAR(255) DEFAULT NULL,
+  date_earned DATE NULL,
+  credential_url VARCHAR(500) DEFAULT NULL,
+  sort_order INT DEFAULT 0,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/app/components/PortfolioShell.jsx
+++ b/src/app/components/PortfolioShell.jsx
@@ -79,6 +79,8 @@ export default function PortfolioShell({
   aboutBullets,
   experienceHeading,
   employers,
+  education,
+  certifications,
   projectsHeading,
   featuredProjects,
   projects,
@@ -186,6 +188,57 @@ export default function PortfolioShell({
           ))}
         </div>
       </section>
+
+      <section id="education" className="mx-auto max-w-6xl px-6 py-8 lg:px-8">
+        <div className="rounded-3xl border border-stone-900/10 bg-white/70 p-8 dark:border-white/10 dark:bg-stone-900/60 lg:p-10">
+          <p className="text-sm font-semibold uppercase tracking-[0.3em] text-orange-700 dark:text-orange-400">Education</p>
+          <h2 className="mt-2 text-3xl font-semibold text-stone-900 dark:text-white">Where it started.</h2>
+
+          <div className="mt-8 grid gap-6 lg:grid-cols-3">
+            {education.map((item) => (
+              <div
+                key={item.slug}
+                className="rounded-2xl border border-stone-900/10 bg-stone-100/70 p-6 dark:border-white/10 dark:bg-stone-950/70"
+              >
+                <p className="text-sm text-orange-700 dark:text-orange-400">{item.dateRange}</p>
+                <h3 className="mt-2 text-lg font-semibold text-stone-900 dark:text-white">{item.institution}</h3>
+                {item.degree && <p className="mt-1 text-sm text-stone-600 dark:text-stone-300">{item.degree}</p>}
+                {item.location && <p className="mt-1 text-sm text-stone-500 dark:text-stone-400">{item.location}</p>}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {certifications.length > 0 && (
+        <section id="certifications" className="mx-auto max-w-6xl px-6 py-8 lg:px-8">
+          <div className="rounded-3xl border border-stone-900/10 bg-white/70 p-8 dark:border-white/10 dark:bg-stone-900/60 lg:p-10">
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-orange-700 dark:text-orange-400">Certifications</p>
+            <h2 className="mt-2 text-3xl font-semibold text-stone-900 dark:text-white">Credentials I've earned.</h2>
+
+            <div className="mt-8 grid gap-6 lg:grid-cols-3">
+              {certifications.map((cert) => {
+                const CertTag = cert.credentialUrl ? "a" : "div";
+                return (
+                  <CertTag
+                    key={cert.slug}
+                    {...(cert.credentialUrl
+                      ? { href: cert.credentialUrl, target: "_blank", rel: "noreferrer" }
+                      : {})}
+                    className="rounded-2xl border border-stone-900/10 bg-stone-100/70 p-6 dark:border-white/10 dark:bg-stone-950/70"
+                  >
+                    {cert.dateEarnedDisplay && (
+                      <p className="text-sm text-orange-700 dark:text-orange-400">{cert.dateEarnedDisplay}</p>
+                    )}
+                    <h3 className="mt-2 text-lg font-semibold text-stone-900 dark:text-white">{cert.name}</h3>
+                    {cert.issuer && <p className="mt-1 text-sm text-stone-500 dark:text-stone-400">{cert.issuer}</p>}
+                  </CertTag>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+      )}
 
       <section id="projects" className="mx-auto max-w-6xl px-6 py-8 lg:px-8">
         <div className="rounded-3xl border border-stone-900/10 bg-white/70 p-8 dark:border-white/10 dark:bg-stone-900/60 lg:p-10">

--- a/src/app/components/SiteHeader.jsx
+++ b/src/app/components/SiteHeader.jsx
@@ -45,6 +45,9 @@ export default function SiteHeader({ employers = [] }) {
           <Link href="/#experience" className={navLinkClass}>
             Experience
           </Link>
+          <Link href="/#education" className={navLinkClass}>
+            Education
+          </Link>
 
           <div className="relative" onMouseEnter={openWork} onMouseLeave={scheduleCloseWork}>
             <button
@@ -106,6 +109,9 @@ export default function SiteHeader({ employers = [] }) {
             </Link>
             <Link href="/#experience" className={navLinkClass} onClick={() => setMobileOpen(false)}>
               Experience
+            </Link>
+            <Link href="/#education" className={navLinkClass} onClick={() => setMobileOpen(false)}>
+              Education
             </Link>
 
             <div>

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,5 +1,11 @@
 import PortfolioShell from "./components/PortfolioShell";
-import { getHomepageData, getProjectList, getEmployers } from "@/lib/portfolio-data";
+import {
+  getCertifications,
+  getEducation,
+  getEmployers,
+  getHomepageData,
+  getProjectList,
+} from "@/lib/portfolio-data";
 
 
 const contactLinks = [
@@ -36,8 +42,14 @@ const contactLinks = [
 ];
 
 export default async function Home() {
-  const [homeData, projects, employers] = await Promise.all([getHomepageData(), getProjectList(), getEmployers()]);
-  
+  const [homeData, projects, employers, education, certifications] = await Promise.all([
+    getHomepageData(),
+    getProjectList(),
+    getEmployers(),
+    getEducation(),
+    getCertifications(),
+  ]);
+
   return (
     <PortfolioShell
       heroEyebrow={homeData.heroEyebrow}
@@ -51,6 +63,8 @@ export default async function Home() {
       aboutBullets={homeData.aboutBullets}
       experienceHeading={homeData.experienceHeading}
       employers={employers.slice(0, 3)}
+      education={education}
+      certifications={certifications}
       projectsHeading={homeData.projectsHeading}
       featuredProjects={homeData.featuredProjects}
       projects={projects}

--- a/src/lib/portfolio-data.js
+++ b/src/lib/portfolio-data.js
@@ -289,6 +289,47 @@ const fallbackEmployers = [
   },
 ];
 
+const fallbackEducation = [
+  {
+    slug: "whitko",
+    institution: "Whitko Community High School",
+    degree: "High School Diploma",
+    startDate: "2011-08-01",
+    endDate: "2016-05-01",
+    location: "South Whitley, IN",
+    sortOrder: 1,
+  },
+  {
+    slug: "ivy-tech",
+    institution: "Ivy Tech Community College",
+    degree: "Associate of Science, Computer Science",
+    startDate: "2017-01-01",
+    endDate: "2019-05-01",
+    location: "Warsaw/Fort Wayne, IN",
+    sortOrder: 2,
+  },
+  {
+    slug: "purdue-fort-wayne",
+    institution: "Purdue University Fort Wayne",
+    degree: "Bachelor of Science, Computer Science",
+    startDate: "2019-08-01",
+    endDate: "2021-05-01",
+    location: "Fort Wayne, IN",
+    sortOrder: 3,
+  },
+];
+
+const fallbackCertifications = [
+  {
+    slug: "python-pcep",
+    name: "Python PCEP Certification",
+    issuer: "Python Institute",
+    dateEarned: "2021-09-01",
+    credentialUrl: null,
+    sortOrder: 1,
+  },
+];
+
 async function getDatabaseConnection() {
   const {
     PORTFOLIO_DB_HOST,
@@ -585,6 +626,84 @@ export async function getEmployerBySlug(slug) {
     console.error(`Employer query failed: ${err.code || ""} ${err.message}`);
     const fallback = fallbackEmployers.find((employer) => employer.slug === slug);
     return fallback ? { ...normalizeEmployerRow(fallback), highlights: fallback.highlights, caseStudies: fallback.caseStudies } : null;
+  } finally {
+    await connection.end();
+  }
+}
+
+function normalizeEducationRow(row) {
+  const startDate = row.start_date ?? row.startDate;
+  const endDate = row.end_date ?? row.endDate;
+  return {
+    slug: row.slug,
+    institution: row.institution,
+    degree: row.degree,
+    startDate: normalizeDate(startDate),
+    endDate: normalizeDate(endDate),
+    dateRange: formatDateRange(startDate, endDate),
+    location: row.location,
+    sortOrder: row.sort_order ?? row.sortOrder,
+  };
+}
+
+export async function getEducation() {
+  const connection = await getDatabaseConnection();
+
+  if (!connection) {
+    return fallbackEducation.map(normalizeEducationRow);
+  }
+
+  try {
+    const [rows] = await connection.query(
+      "SELECT slug, institution, degree, start_date, end_date, location, sort_order FROM portfolio_education ORDER BY sort_order ASC",
+    );
+
+    if (!rows?.length) {
+      return fallbackEducation.map(normalizeEducationRow);
+    }
+
+    return rows.map(normalizeEducationRow);
+  } catch (err) {
+    console.error(`Education query failed: ${err.code || ""} ${err.message}`);
+    return fallbackEducation.map(normalizeEducationRow);
+  } finally {
+    await connection.end();
+  }
+}
+
+function normalizeCertificationRow(row) {
+  const dateEarned = row.date_earned ?? row.dateEarned;
+  return {
+    slug: row.slug,
+    name: row.name,
+    issuer: row.issuer,
+    dateEarned: normalizeDate(dateEarned),
+    dateEarnedDisplay: formatMonthYear(dateEarned),
+    credentialUrl: row.credential_url ?? row.credentialUrl ?? null,
+    sortOrder: row.sort_order ?? row.sortOrder,
+  };
+}
+
+export async function getCertifications() {
+  const connection = await getDatabaseConnection();
+
+  if (!connection) {
+    return fallbackCertifications.map(normalizeCertificationRow);
+  }
+
+  try {
+    const [rows] = await connection.query(
+      "SELECT slug, name, issuer, date_earned, credential_url, sort_order FROM portfolio_certifications ORDER BY sort_order ASC",
+    );
+
+    if (!rows?.length) {
+      return fallbackCertifications.map(normalizeCertificationRow);
+    }
+
+    return rows.map(normalizeCertificationRow);
+  } catch (err) {
+    console.error(`Certifications query failed: ${err.code || ""} ${err.message}`);
+    return fallbackCertifications.map(normalizeCertificationRow);
   } finally {
     await connection.end();
   }


### PR DESCRIPTION
Both get their own tables (portfolio_education, portfolio_certifications) rather than folding into portfolio_employers -- a degree isn't a job, so the fields don't overlap cleanly (no job title, an issuer instead of a company, etc). Seeded with Whitko (2011-2016), Ivy Tech (2017-2019, AS Computer Science), Purdue Fort Wayne (2019-2021, BS Computer Science), and the Python PCEP certification (Sept 2021).

New homepage sections placed right after Experience, plus an "Education" link in the header nav (Certifications sits directly below it, so a separate nav entry felt redundant). Certifications section only renders if there's at least one row, so it disappears gracefully if the table is ever empty.