### PR TITLE
Rename package to ryans-portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To run this application locally, follow these steps:
 1. Clone the repository:
 
 ```bash
-git clone https://github.com/rh7112/personal-portfolio.git
+git clone https://github.com/rh7112/ryans-portfolio.git
 ```
 
 2. Install dependencies:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "personal-portfolio",
+  "name": "ryans-portfolio",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "personal-portfolio",
+      "name": "ryans-portfolio",
       "version": "0.1.0",
       "dependencies": {
         "next": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "personal-portfolio",
+  "name": "ryans-portfolio",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary
- Renames the npm package from `personal-portfolio` to `ryans-portfolio`, matching the already-renamed GitHub repo (`rh7112/ryans-portfolio`) and Alycia's portfolio's naming scheme.
- Updates the README clone URL to match.
- `wrangler.jsonc`'s project name is intentionally left alone for now — it needs to stay in sync with the actual Cloudflare Pages project name, which hasn't been renamed on Cloudflare's side yet.

## Test plan
- [x] `npm run build` succeeds
- [x] `package-lock.json` regenerated and matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)