### PR TITLE
Fix wrangler.jsonc project name mismatch

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "personal-portfolio",
+  "name": "ryans-portfolio",
   "compatibility_date": "2026-08-05",
   "observability": {
     "enabled": false,


### PR DESCRIPTION
## Summary
- Fixes `wrangler.jsonc`'s `"name"` field from `personal-portfolio` to `ryans-portfolio`, matching the Cloudflare Pages project after it was renamed.
- **Urgent**: the CF project was renamed before this file was updated, and a manual rebuild trigger landed in that gap — the build's `wrangler deploy` step ran with the stale name, which may have created a stray duplicate Pages project. Merging this stops every future deploy (including the hourly scheduled rebuild) from repeating that mismatch.

## Test plan
- [x] `npm run build` succeeds
- [ ] Confirm on the Cloudflare dashboard whether a stray `personal-portfolio` project was created, and clean it up if so
- [ ] Confirm `ryan.hurd.cc`'s custom domain is still bound to the `ryans-portfolio` project after this merges and the next rebuild runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)