### PR TITLE
Add API Docs link to footer

### DIFF
--- a/src/app/components/PortfolioShell.jsx
+++ b/src/app/components/PortfolioShell.jsx
@@ -9,6 +9,7 @@ import ProjectsCarousel from "./ProjectsCarousel";
 
 import {
   FaArrowRight,
+  FaCode,
   FaEnvelope,
   FaFileAlt,
   FaGithub,
@@ -400,8 +401,16 @@ export default function PortfolioShell({
             })}
           </div>
 
-          <div className="mt-6">
+          <div className="mt-6 flex flex-wrap items-center gap-4">
             <BuyMeACoffeeButton />
+            <a
+              href="https://api.hurd.cc/docs/"
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-1.5 text-xs text-stone-500 transition hover:text-orange-700 dark:text-stone-400 dark:hover:text-orange-400"
+            >
+              <FaCode /> API Docs
+            </a>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Adds a small "API Docs" link to the Contact/footer section, pointing to `https://api.hurd.cc/docs/` (portfolio-api's Swagger UI).
- Styled as a quiet, understated aside next to the Buy Me a Coffee button — not a primary nav item, just a small credibility signal for technical visitors.
- Intentionally scoped to this repo only, not alycias-portfolio or blog.hurd.cc.

## Test plan
- [x] `npm run build` succeeds
- [x] Verified target URL resolves (`HTTP 200`)
- [x] Verified locally: link renders correctly in the Contact section, opens in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)