### PR TITLE
Add clickable project links, plus new personal projects

### DIFF
--- a/docs/mariadb-setup.sql
+++ b/docs/mariadb-setup.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS portfolio_projects (
   company_slug VARCHAR(150) DEFAULT NULL,
   color VARCHAR(50) DEFAULT 'sky',
   tech_stack VARCHAR(255) DEFAULT NULL,
+  link VARCHAR(500) DEFAULT NULL,
   featured TINYINT(1) DEFAULT 0,
   published TINYINT(1) DEFAULT 1,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -114,6 +115,10 @@ INSERT INTO portfolio_projects (title, summary, image, company, company_slug, co
 ('PC Building', 'Built a PC in 2017 and have been upgrading and maintaining it ever since.', NULL, 'Personal Projects', 'personal-projects', 'sky', 'Hardware', 0, 1),
 ('Technology Repair', 'Repaired game consoles including PlayStation, Switch, and Xbox hardware.', NULL, 'Personal Projects', 'personal-projects', 'sky', 'Hardware repair', 0, 1),
 ('Household Projects', 'General contractor-style home projects: fan installation, spackling and painting, converting a bay window into a slider door, and electrical updates.', NULL, 'Personal Projects', 'personal-projects', 'sky', 'Home improvement', 0, 1),
+('Raspberry Pi Steam Link', 'Set up a Raspberry Pi running Steam Link to stream PC games to the TV.', NULL, 'Personal Projects', 'personal-projects', 'sky', 'Raspberry Pi, Steam Link', 0, 1),
+('Alycia''s Portfolio', 'Built a separate portfolio site for Alycia using SvelteKit and Tailwind CSS, backed by portfolio-api''s isolated Alycia tenant.', NULL, 'Personal Projects', 'personal-projects', 'sky', 'SvelteKit, Tailwind CSS, portfolio-api', 0, 1),
+('portfolio-api (Go)', 'Built a Go REST API backed by MariaDB as the shared read/write layer for this site, Alycia''s portfolio, and blog.hurd.cc, replacing direct database queries from each site.', NULL, 'Personal Projects', 'personal-projects', 'sky', 'Go, MariaDB, Docker', 0, 1),
+('Morel Mushroom Hunting App (Concept)', 'A planned application for tracking morel mushroom hunting spots and conditions. Not yet started, but scoped out enough to move quickly once picked up.', NULL, 'Personal Projects', 'personal-projects', 'sky', NULL, 0, 1),
 ('Yield Report', 'A reporting experience that surfaced production, material, and customer-job trends in a clearer way for operations and leadership.', '/images/projects/ppi-yield-report.svg', 'Packaging Personified, Inc.', 'packaging-personified', 'sky', 'Retool, Excel, DL4, PKP, Access', 1, 1),
 ('EPA Reporting', 'A compliance-focused reporting workflow that consolidated multiple sources into a more maintainable experience.', '/images/projects/ppi-epa-reporting-screenshot.png', 'Packaging Personified, Inc.', 'packaging-personified', 'sky', 'Retool, Excel, DL4, PKP, Access', 1, 1),
 ('Press WIP Optimization', 'A workflow efficiency project that reduced processing time and improved usability for day-to-day operations, improving speed by over 40%.', '/images/projects/ppi-press-wip.svg', 'Packaging Personified, Inc.', 'packaging-personified', 'sky', 'Retool, DL4, PKP, Access', 1, 1),
@@ -154,6 +159,15 @@ INSERT INTO portfolio_projects (title, summary, image, company, company_slug, co
 ('Phase 10 Dice', 'Developed the Phase 10 Dice game as the final project for an introductory programming course.', '/images/projects/phase-10-dice.jpg', 'Ivy Tech', 'ivy-tech', 'sky', 'C++', 0, 1),
 ('Banking Application', 'Built a banking application as a course project.', NULL, 'Ivy Tech', 'ivy-tech', 'sky', 'C++', 0, 1)
 ON DUPLICATE KEY UPDATE summary = VALUES(summary), image = VALUES(image), company = VALUES(company), color = VALUES(color), tech_stack = VALUES(tech_stack), featured = VALUES(featured), published = VALUES(published);
+
+-- Projects with an external link (repo, live docs, etc.), rendered as
+-- clickable on the site instead of static text. Separate INSERT since these
+-- are the only rows in this file that set the `link` column.
+INSERT INTO portfolio_projects (title, summary, image, company, company_slug, color, tech_stack, link, featured, published) VALUES
+('BBSystems.US Website', 'An in-progress website project for BBSystems.US, currently in the planning stage while scoping requirements with the site''s owner, Cruz Gregory.', NULL, 'Personal Projects', 'personal-projects', 'sky', NULL, 'https://github.com/rh7112/bbsystems-us', 0, 1),
+('blog.hurd.cc Extraction', 'Split the blog and recipes content out of this portfolio into its own site, including migrating the data into portfolio-api''s isolated hurd_blog database.', NULL, 'Personal Projects', 'personal-projects', 'sky', 'Next.js, portfolio-api', 'https://blog.hurd.cc', 0, 1),
+('portfolio-api Swagger Docs', 'Set up Swagger/OpenAPI documentation for portfolio-api, giving a browsable, interactive reference for its REST endpoints.', NULL, 'Personal Projects', 'personal-projects', 'sky', 'Swagger/OpenAPI, Go', 'https://api.hurd.cc/docs/', 0, 1)
+ON DUPLICATE KEY UPDATE summary = VALUES(summary), image = VALUES(image), company = VALUES(company), color = VALUES(color), tech_stack = VALUES(tech_stack), link = VALUES(link), featured = VALUES(featured), published = VALUES(published);
 
 -- Employers: single source of truth for homepage Experience cards, the
 -- header's Work dropdown, and /experience/[slug] pages.

--- a/docs/migrations/007_add_project_link.sql
+++ b/docs/migrations/007_add_project_link.sql
@@ -1,0 +1,5 @@
+-- Adds an optional external link to projects (repo, live docs, etc.), so
+-- ryans-portfolio can render the project as clickable instead of static text.
+
+ALTER TABLE portfolio_projects
+  ADD COLUMN link VARCHAR(500) DEFAULT NULL AFTER tech_stack;

--- a/src/app/components/PortfolioShell.jsx
+++ b/src/app/components/PortfolioShell.jsx
@@ -255,15 +255,25 @@ export default function PortfolioShell({
                   {group.company}
                 </h4>
                 <div className="mt-3 flex flex-wrap gap-3">
-                  {group.items.map((project) => (
-                    <span
-                      key={project.id}
-                      title={project.company}
-                      className={`rounded-full border px-3 py-2 text-sm text-stone-700 dark:text-stone-200 ${getCompanyCardClass(group.color)}`}
-                    >
-                      {project.title}
-                    </span>
-                  ))}
+                  {group.items.map((project) => {
+                    const pillClassName = `rounded-full border px-3 py-2 text-sm text-stone-700 dark:text-stone-200 ${getCompanyCardClass(group.color)}`;
+                    return project.link ? (
+                      <a
+                        key={project.id}
+                        href={project.link}
+                        target="_blank"
+                        rel="noreferrer"
+                        title={project.company}
+                        className={`${pillClassName} transition hover:border-orange-600 dark:hover:border-orange-400`}
+                      >
+                        {project.title}
+                      </a>
+                    ) : (
+                      <span key={project.id} title={project.company} className={pillClassName}>
+                        {project.title}
+                      </span>
+                    );
+                  })}
                 </div>
               </div>
             ))}

--- a/src/app/components/ProjectsCarousel.jsx
+++ b/src/app/components/ProjectsCarousel.jsx
@@ -35,30 +35,37 @@ export default function ProjectsCarousel({ projects }) {
   return (
     <>
       <div className="mt-8 grid gap-6 lg:grid-cols-3">
-        {visibleProjects.map((project) => (
-          <article
-            key={project.id ?? project.title}
-            className={`overflow-hidden rounded-3xl border ${project.cardClassName}`}
-          >
-            <div className="relative h-48 w-full">
-              <Image src={project.image} alt={project.title} fill className="object-cover" />
-            </div>
-            <div className="p-6">
-              <h3 className="text-xl font-semibold text-stone-900 dark:text-white">{project.title}</h3>
-              {project.company && (
-                <p className="mt-1 text-xs uppercase tracking-[0.2em] text-stone-500 dark:text-stone-400">
-                  {project.company}
-                </p>
-              )}
-              <p className="mt-3 text-sm leading-7 text-stone-600 dark:text-stone-300">{project.summary}</p>
-              {project.techStack && (
-                <p className="mt-3 text-xs uppercase tracking-[0.15em] text-stone-500 dark:text-stone-400">
-                  {project.techStack}
-                </p>
-              )}
-            </div>
-          </article>
-        ))}
+        {visibleProjects.map((project) => {
+          const Wrapper = project.link ? "a" : "article";
+          const linkProps = project.link ? { href: project.link, target: "_blank", rel: "noreferrer" } : {};
+          return (
+            <Wrapper
+              key={project.id ?? project.title}
+              {...linkProps}
+              className={`block overflow-hidden rounded-3xl border ${project.cardClassName} ${
+                project.link ? "transition hover:-translate-y-0.5 hover:shadow-md" : ""
+              }`}
+            >
+              <div className="relative h-48 w-full">
+                <Image src={project.image} alt={project.title} fill className="object-cover" />
+              </div>
+              <div className="p-6">
+                <h3 className="text-xl font-semibold text-stone-900 dark:text-white">{project.title}</h3>
+                {project.company && (
+                  <p className="mt-1 text-xs uppercase tracking-[0.2em] text-stone-500 dark:text-stone-400">
+                    {project.company}
+                  </p>
+                )}
+                <p className="mt-3 text-sm leading-7 text-stone-600 dark:text-stone-300">{project.summary}</p>
+                {project.techStack && (
+                  <p className="mt-3 text-xs uppercase tracking-[0.15em] text-stone-500 dark:text-stone-400">
+                    {project.techStack}
+                  </p>
+                )}
+              </div>
+            </Wrapper>
+          );
+        })}
       </div>
 
       {canRotate && (

--- a/src/lib/portfolio-data.js
+++ b/src/lib/portfolio-data.js
@@ -446,6 +446,7 @@ function normalizeProjectRows(rows) {
     companySlug: row.company_slug || row.companySlug,
     color: row.color || "sky",
     techStack: row.tech_stack ?? row.techStack ?? null,
+    link: row.link ?? null,
     featured: Boolean(row.featured),
     published: Boolean(row.published),
   }));


### PR DESCRIPTION
## Summary
- Adds an optional `link` column to `portfolio_projects` (migration `007_add_project_link.sql`) — projects with a link render as clickable (new tab) in both the "Project History" pills and the `ProjectsCarousel` cards; falls back to static text/cards otherwise.
- Adds 7 new Personal Projects entries:
  - **Raspberry Pi Steam Link**, **Alycia's Portfolio**, **portfolio-api (Go)** — no link (Alycia's site is gated behind Cloudflare Access, portfolio-api's repo is private — verified both, not guessed)
  - **Morel Mushroom Hunting App** — explicitly marked as a not-yet-started concept, per your call
  - **BBSystems.US Website** (links to the GitHub repo, still in planning), **blog.hurd.cc Extraction** (links to the live site), **portfolio-api Swagger Docs** (links to the live `/docs/` page)
- Corresponding `portfolio-api` changes (Go model, schema, store layer) are committed in that repo separately — still needs to be pushed and the live API redeployed for `link` to actually round-trip.

## Test plan
- [x] `npm run build` succeeds
- [x] `go build ./...` and `go test ./...` pass in portfolio-api
- [ ] Once merged + DB migration run + portfolio-api redeployed: verify a project with a link actually renders clickable on the live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)