### PR TITLE
Add real certification verification links

### DIFF
--- a/docs/mariadb-setup.sql
+++ b/docs/mariadb-setup.sql
@@ -251,8 +251,9 @@ INSERT INTO portfolio_education (slug, institution, degree, start_date, end_date
 ON DUPLICATE KEY UPDATE institution = VALUES(institution), degree = VALUES(degree), start_date = VALUES(start_date), end_date = VALUES(end_date), location = VALUES(location), sort_order = VALUES(sort_order);
 
 INSERT INTO portfolio_certifications (slug, name, issuer, date_earned, credential_url, score, expired, sort_order) VALUES
-('python-pcep', 'Python PCEP Certification', 'Python Institute', '2021-09-01', NULL, NULL, 0, 1),
+('python-pcep', 'Python PCEP Certification', 'Python Institute', '2021-09-24', 'https://pythoninstitute.org/credential-verification', NULL, 0, 1),
 ('comptia-a-plus', 'CompTIA A+', 'CompTIA', '2017-12-01', NULL, '1880', 1, 2),
-('retool-platform-admin', 'Retool Platform Admin', 'Retool', '2025-03-01', NULL, NULL, 0, 3),
-('retool-platform-developer', 'Retool Platform Developer', 'Retool', '2025-03-01', NULL, NULL, 0, 4)
+('retool-platform-admin', 'Retool Platform Admin', 'Retool', '2025-03-20', 'https://www.credly.com/badges/ff682844-9d1f-4336-9f49-6622bdce25c5/linked_in_profile', NULL, 0, 3),
+('retool-platform-developer', 'Retool Platform Developer', 'Retool', '2025-03-19', 'https://www.credly.com/badges/9d9a47c9-09dd-4527-ab31-ab6766df44de/linked_in_profile', NULL, 0, 4),
+('testout-pc-pro', 'TestOut PC Pro', 'TestOut', '2017-12-13', 'https://webservices.testout.com/OrbisServerJson/DownloadCertificates.aspx?certificateSetGuid=a82a3791-07ad-4736-9cb5-bc8af4a98f13', NULL, 0, 5)
 ON DUPLICATE KEY UPDATE name = VALUES(name), issuer = VALUES(issuer), date_earned = VALUES(date_earned), credential_url = VALUES(credential_url), score = VALUES(score), expired = VALUES(expired), sort_order = VALUES(sort_order);


### PR DESCRIPTION
Closes #55.

## Summary
- **Python PCEP**: links to Python Institute's credential-verification page. Deliberately not embedding the actual verification code in a public URL -- that's meant to be shared selectively (e.g. with a specific recruiter), not published for anyone to use.
- **Retool Platform Admin / Developer**: real Credly badge links, confirmed by checking Ryan's live Credly profile directly (not guessed). Also corrected `date_earned` to the exact issue dates (Mar 20/19, 2025) instead of the previous month-only placeholder.
- **CompTIA A+**: left alone -- no real CompTIA verification link available.
- **TestOut PC Pro**: added as its own new certification entry rather than attaching its PDF link to the CompTIA A+ entry -- confirmed via the PDF's own contents that these are correlated but distinct credentials from different issuers.

## Test plan
- [x] `npm run build` succeeds
- [x] All three external links (Python Institute page, both Credly badges) verified to actually resolve and show the expected credential

🤖 Generated with [Claude Code](https://claude.com/claude-code)