### PR TITLE
Add manual dark/light mode toggle

### DIFF
--- a/src/app/components/SiteHeader.jsx
+++ b/src/app/components/SiteHeader.jsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { FaBars, FaChevronDown, FaTimes } from "react-icons/fa";
 
+import ThemeToggle from "./ThemeToggle";
+
 const navLinkClass = "transition hover:text-stone-900 dark:hover:text-white";
 
 export default function SiteHeader({ employers = [] }) {
@@ -94,14 +96,18 @@ export default function SiteHeader({ employers = [] }) {
           </Link>
         </div>
 
-        <button
-          type="button"
-          className="inline-flex items-center justify-center rounded-full border border-stone-900/10 p-2 text-stone-700 dark:border-white/10 dark:text-stone-200 md:hidden"
-          onClick={() => setMobileOpen((open) => !open)}
-          aria-label="Toggle menu"
-        >
-          {mobileOpen ? <FaTimes /> : <FaBars />}
-        </button>
+        <div className="flex items-center gap-2">
+          <ThemeToggle />
+
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-full border border-stone-900/10 p-2 text-stone-700 dark:border-white/10 dark:text-stone-200 md:hidden"
+            onClick={() => setMobileOpen((open) => !open)}
+            aria-label="Toggle menu"
+          >
+            {mobileOpen ? <FaTimes /> : <FaBars />}
+          </button>
+        </div>
       </div>
 
       {mobileOpen && (

--- a/src/app/components/ThemeToggle.jsx
+++ b/src/app/components/ThemeToggle.jsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FaMoon, FaSun } from "react-icons/fa";
+
+function getStoredTheme() {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return window.localStorage.getItem("theme");
+}
+
+function applyTheme(theme) {
+  const root = document.documentElement;
+  root.classList.remove("dark", "light");
+  if (theme === "dark" || theme === "light") {
+    root.classList.add(theme);
+  }
+}
+
+export default function ThemeToggle() {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const stored = getStoredTheme();
+    const systemDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    setIsDark(stored ? stored === "dark" : systemDark);
+  }, []);
+
+  function toggleTheme() {
+    const next = isDark ? "light" : "dark";
+    setIsDark(!isDark);
+    window.localStorage.setItem("theme", next);
+    applyTheme(next);
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      className="inline-flex items-center justify-center rounded-full border border-stone-900/10 p-2 text-stone-700 transition hover:border-orange-600 hover:text-stone-900 dark:border-white/10 dark:text-stone-200 dark:hover:border-orange-400 dark:hover:text-white"
+    >
+      {isDark ? <FaSun /> : <FaMoon />}
+    </button>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,16 +1,29 @@
 @import "tailwindcss";
 
+/* Lets `dark:` utilities respond to a `.dark` class on <html> (set by
+   ThemeToggle) instead of only prefers-color-scheme, so the manual toggle
+   can actually override the system preference. */
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
   color-scheme: light dark;
   --background: #fafaf9;
   --foreground: #1c1917;
 }
 
+/* System preference applies dark, unless the user has explicitly chosen
+   light via the toggle (.light class short-circuits this). */
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root:not(.light) {
     --background: #0c0a09;
     --foreground: #fafaf9;
   }
+}
+
+/* Explicit dark choice always wins, regardless of system preference. */
+:root.dark {
+  --background: #0c0a09;
+  --foreground: #fafaf9;
 }
 
 html {
@@ -27,10 +40,15 @@ body {
 }
 
 @media (prefers-color-scheme: dark) {
-  body {
+  :root:not(.light) body {
     background: radial-gradient(circle at top left, rgba(251, 146, 60, 0.16), transparent 28%),
       linear-gradient(135deg, #0c0a09 0%, #1c1917 100%);
   }
+}
+
+:root.dark body {
+  background: radial-gradient(circle at top left, rgba(251, 146, 60, 0.16), transparent 28%),
+    linear-gradient(135deg, #0c0a09 0%, #1c1917 100%);
 }
 
 * {

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -63,12 +63,31 @@ const personJsonLd = {
   ],
 };
 
+// Applies a stored manual theme choice before first paint, so there's no
+// flash of the wrong theme while React hydrates. Runs synchronously as the
+// first thing in <body>; suppressHydrationWarning on <html> is needed
+// because this intentionally changes className before hydration compares it.
+const themeInitScript = `
+(function () {
+  try {
+    var theme = window.localStorage.getItem("theme");
+    if (theme === "dark" || theme === "light") {
+      document.documentElement.classList.add(theme);
+    }
+  } catch (e) {}
+})();
+`;
+
 export default async function RootLayout({ children }) {
   const employers = await getEmployers();
 
   return (
-    <html lang="en" className="scroll-smooth">
+    <html lang="en" className="scroll-smooth" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <script
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: themeInitScript }}
+        />
         <script
           type="application/ld+json"
           // eslint-disable-next-line react/no-danger


### PR DESCRIPTION
Closes #48.

Toggle button in the header (always visible), persists choice via localStorage, no flash-of-wrong-theme on load. Verified in-browser end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)