### PR TITLE
Add GitHub activity/stats widget

### DIFF
--- a/src/app/components/PortfolioShell.jsx
+++ b/src/app/components/PortfolioShell.jsx
@@ -113,6 +113,7 @@ export default function PortfolioShell({
   education,
   certifications,
   psnTrophies,
+  githubStats,
   projectsHeading,
   featuredProjects,
   projects,
@@ -387,6 +388,43 @@ export default function PortfolioShell({
                 ))}
               </div>
             )}
+          </div>
+        </section>
+      )}
+
+      {githubStats && (
+        <section className="mx-auto max-w-6xl px-6 py-8 lg:px-8">
+          <div className="rounded-3xl border border-stone-900/10 bg-white/70 p-8 dark:border-white/10 dark:bg-stone-900/60 lg:p-10">
+            <div className="flex flex-wrap items-baseline justify-between gap-4">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-orange-700 dark:text-orange-400">
+                  On GitHub
+                </p>
+                <h2 className="mt-2 text-2xl font-semibold text-stone-900 dark:text-white">
+                  A look at the public side of the work.
+                </h2>
+              </div>
+              <a
+                href={githubStats.profileUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-2 text-sm font-medium text-orange-700 transition hover:text-orange-600 dark:text-orange-400 dark:hover:text-orange-300"
+              >
+                <FaGithub /> View profile
+              </a>
+            </div>
+
+            <div className="mt-6 flex flex-wrap gap-3 text-sm">
+              <span className="rounded-full border border-stone-900/10 bg-stone-100/70 px-4 py-2 text-stone-700 dark:border-white/10 dark:bg-stone-950/70 dark:text-stone-200">
+                📦 Public repos: {githubStats.publicRepos}
+              </span>
+              <span className="rounded-full border border-stone-900/10 bg-stone-100/70 px-4 py-2 text-stone-700 dark:border-white/10 dark:bg-stone-950/70 dark:text-stone-200">
+                ⭐ Total stars: {githubStats.totalStars}
+              </span>
+              <span className="rounded-full border border-stone-900/10 bg-stone-100/70 px-4 py-2 text-stone-700 dark:border-white/10 dark:bg-stone-950/70 dark:text-stone-200">
+                👤 Followers: {githubStats.followers}
+              </span>
+            </div>
           </div>
         </section>
       )}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -6,6 +6,7 @@ import {
   getHomepageData,
   getProjectList,
 } from "@/lib/portfolio-data";
+import { getGitHubStats } from "@/lib/github-data";
 import { getPsnTrophies } from "@/lib/psn-data";
 
 const contactLinks = [
@@ -42,13 +43,14 @@ const contactLinks = [
 ];
 
 export default async function Home() {
-  const [homeData, projects, employers, education, certifications, psnTrophies] = await Promise.all([
+  const [homeData, projects, employers, education, certifications, psnTrophies, githubStats] = await Promise.all([
     getHomepageData(),
     getProjectList(),
     getEmployers(),
     getEducation(),
     getCertifications(),
     getPsnTrophies(),
+    getGitHubStats(),
   ]);
 
   return (
@@ -67,6 +69,7 @@ export default async function Home() {
       education={education}
       certifications={certifications}
       psnTrophies={psnTrophies}
+      githubStats={githubStats}
       projectsHeading={homeData.projectsHeading}
       featuredProjects={homeData.featuredProjects}
       projects={projects}

--- a/src/lib/github-data.js
+++ b/src/lib/github-data.js
@@ -1,0 +1,43 @@
+const GITHUB_USERNAME = "rh7112";
+
+// Unauthenticated GitHub API calls are rate-limited to 60/hr per IP, which
+// is plenty for a once-per-build fetch -- but Cloudflare's shared build
+// fleet means that IP isn't exclusively ours, so this can plausibly get
+// rate-limited by unrelated traffic. Fails soft: returns null and the
+// widget just doesn't render, same pattern as PSN trophies.
+export async function getGitHubStats() {
+  try {
+    const [userRes, reposRes] = await Promise.all([
+      fetch(`https://api.github.com/users/${GITHUB_USERNAME}`, {
+        headers: { Accept: "application/vnd.github+json" },
+        signal: AbortSignal.timeout(5000),
+      }),
+      fetch(`https://api.github.com/users/${GITHUB_USERNAME}/repos?per_page=100`, {
+        headers: { Accept: "application/vnd.github+json" },
+        signal: AbortSignal.timeout(5000),
+      }),
+    ]);
+
+    if (!userRes.ok || !reposRes.ok) {
+      console.error(`GitHub API request failed: user=${userRes.status} repos=${reposRes.status}`);
+      return null;
+    }
+
+    const user = await userRes.json();
+    const repos = await reposRes.json();
+
+    const totalStars = repos
+      .filter((repo) => !repo.fork)
+      .reduce((sum, repo) => sum + (repo.stargazers_count || 0), 0);
+
+    return {
+      publicRepos: user.public_repos,
+      followers: user.followers,
+      totalStars,
+      profileUrl: user.html_url,
+    };
+  } catch (err) {
+    console.error(`GitHub stats fetch failed: ${err.message}`);
+    return null;
+  }
+}


### PR DESCRIPTION
Closes #56.

Public repos, total stars, followers -- fetched via GitHub's unauthenticated REST API at build time. Fails soft on rate limit/errors (section just doesn't render). Verified against live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)