### PR TITLE
Add Lighthouse CI check on PRs

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,33 @@
+name: Lighthouse CI
+
+# Reports performance/accessibility/best-practices/SEO scores on PRs so
+# regressions are visible before merge. Informational only for now (doesn't
+# block merges) -- can add score thresholds via lhci assert later once
+# there's a baseline to tune against.
+
+on:
+  pull_request:
+
+jobs:
+  lighthouse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v11
+        with:
+          staticDistDir: ./out
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Run Lighthouse CI
         uses: treosh/lighthouse-ci-action@v11
         with:
-          staticDistDir: ./out
+          configPath: ./.lighthouserc.json
           uploadArtifacts: true
           temporaryPublicStorage: true

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -1,0 +1,10 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./out"
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
Closes #53.

Runs Lighthouse against the built static export on every PR (performance/accessibility/best-practices/SEO). Informational only for now, not blocking, until there's a baseline to set thresholds against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)