### PR TITLE
Add individual project detail pages (/projects/[slug])

### DIFF
--- a/docs/mariadb-setup.sql
+++ b/docs/mariadb-setup.sql
@@ -16,6 +16,7 @@ CREATE TABLE IF NOT EXISTS portfolio_content (
 
 CREATE TABLE IF NOT EXISTS portfolio_projects (
   id INT AUTO_INCREMENT PRIMARY KEY,
+  slug VARCHAR(255) DEFAULT NULL,
   title VARCHAR(255) NOT NULL,
   summary TEXT NOT NULL,
   image VARCHAR(255) DEFAULT NULL,
@@ -27,7 +28,8 @@ CREATE TABLE IF NOT EXISTS portfolio_projects (
   featured TINYINT(1) DEFAULT 0,
   published TINYINT(1) DEFAULT 1,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  UNIQUE KEY uq_project_title_company (title, company_slug)
+  UNIQUE KEY uq_project_title_company (title, company_slug),
+  UNIQUE KEY uq_project_slug (slug)
 );
 
 -- Single source of truth for work history: the homepage Experience cards, the
@@ -109,6 +111,18 @@ ON DUPLICATE KEY UPDATE `value` = VALUES(`value`);
 -- rename explicitly; it's a no-op on any re-run once the title has changed.
 UPDATE portfolio_projects SET title = 'Ryan''s Portfolio', image = '/images/projects/ryans-portfolio.png'
   WHERE title = 'Personal Portfolio' AND company_slug = 'personal-projects';
+
+-- Slugs for the featured projects that get a dedicated /projects/[slug]
+-- detail page. Plain UPDATEs (not part of the bulk INSERT below) since
+-- these rows already exist -- idempotent, safe to re-run.
+UPDATE portfolio_projects SET slug = 'ryans-portfolio' WHERE title = 'Ryan''s Portfolio' AND company_slug = 'personal-projects';
+UPDATE portfolio_projects SET slug = 'yield-report' WHERE title = 'Yield Report' AND company_slug = 'packaging-personified';
+UPDATE portfolio_projects SET slug = 'epa-reporting' WHERE title = 'EPA Reporting' AND company_slug = 'packaging-personified';
+UPDATE portfolio_projects SET slug = 'press-wip-optimization' WHERE title = 'Press WIP Optimization' AND company_slug = 'packaging-personified';
+UPDATE portfolio_projects SET slug = 'gear-exchange-braintree' WHERE title = 'Gear Exchange - Braintree Implementation' AND company_slug = 'sweetwater-sound';
+UPDATE portfolio_projects SET slug = 'price-management-platform' WHERE title = 'Price Management Platform' AND company_slug = 'sweetwater-sound';
+UPDATE portfolio_projects SET slug = 'ecms' WHERE title = 'Tax Exemption Certification Management System (ECMS)' AND company_slug = 'sweetwater-sound';
+UPDATE portfolio_projects SET slug = 'turkey-handout-application' WHERE title = 'Turkey Handout Application' AND company_slug = 'sweetwater-sound';
 
 INSERT INTO portfolio_projects (title, summary, image, company, company_slug, color, tech_stack, featured, published) VALUES
 ('Ryan''s Portfolio', 'Built this portfolio to expand knowledge of Next.js, HeroUI, and MariaDB while showcasing professional experience.', '/images/projects/ryans-portfolio.png', 'Personal Projects', 'personal-projects', 'sky', 'Next.js, HeroUI, MariaDB', 1, 1),

--- a/docs/migrations/008_add_project_slug.sql
+++ b/docs/migrations/008_add_project_slug.sql
@@ -1,0 +1,7 @@
+-- Adds an optional URL-friendly slug to projects, so featured/notable
+-- projects can get a dedicated detail page at /projects/[slug] instead of
+-- only showing as a carousel card or Project History pill.
+
+ALTER TABLE portfolio_projects
+  ADD COLUMN slug VARCHAR(255) DEFAULT NULL AFTER id,
+  ADD UNIQUE KEY uq_project_slug (slug);

--- a/src/app/components/PortfolioShell.jsx
+++ b/src/app/components/PortfolioShell.jsx
@@ -280,6 +280,20 @@ export default function PortfolioShell({
                 <div className="mt-3 flex flex-wrap gap-3">
                   {group.items.map((project) => {
                     const pillClassName = `rounded-full border px-3 py-2 text-sm text-stone-700 dark:text-stone-200 ${getCompanyCardClass(group.color)}`;
+                    // A detail page beats an external link when a project
+                    // happens to have both -- keeps visitors on the site.
+                    if (project.slug) {
+                      return (
+                        <Link
+                          key={project.id}
+                          href={`/projects/${project.slug}`}
+                          title={project.company}
+                          className={`${pillClassName} transition hover:border-orange-600 dark:hover:border-orange-400`}
+                        >
+                          {project.title}
+                        </Link>
+                      );
+                    }
                     return project.link ? (
                       <a
                         key={project.id}

--- a/src/app/components/ProjectsCarousel.jsx
+++ b/src/app/components/ProjectsCarousel.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import { FaPause, FaPlay } from "react-icons/fa";
 
@@ -36,14 +37,21 @@ export default function ProjectsCarousel({ projects }) {
     <>
       <div className="mt-8 grid gap-6 lg:grid-cols-3">
         {visibleProjects.map((project) => {
-          const Wrapper = project.link ? "a" : "article";
-          const linkProps = project.link ? { href: project.link, target: "_blank", rel: "noreferrer" } : {};
+          // A detail page beats an external link when a project happens to
+          // have both -- keeps visitors on the site.
+          const hasLink = Boolean(project.slug || project.link);
+          const Wrapper = project.slug ? Link : project.link ? "a" : "article";
+          const linkProps = project.slug
+            ? { href: `/projects/${project.slug}` }
+            : project.link
+              ? { href: project.link, target: "_blank", rel: "noreferrer" }
+              : {};
           return (
             <Wrapper
               key={project.id ?? project.title}
               {...linkProps}
               className={`block overflow-hidden rounded-3xl border ${project.cardClassName} ${
-                project.link ? "transition hover:-translate-y-0.5 hover:shadow-md" : ""
+                hasLink ? "transition hover:-translate-y-0.5 hover:shadow-md" : ""
               }`}
             >
               <div className="relative h-48 w-full">

--- a/src/app/projects/[slug]/page.js
+++ b/src/app/projects/[slug]/page.js
@@ -1,0 +1,137 @@
+import Link from "next/link";
+import Image from "next/image";
+import { FaArrowLeft, FaArrowUpRightFromSquare } from "react-icons/fa6";
+import { getProjectBySlug, getProjectsWithSlugs } from "@/lib/portfolio-data";
+
+// output: "export" hard-fails a build if generateStaticParams returns zero
+// routes. Until the 008_add_project_slug migration actually runs against
+// the live DB, portfolio-api has no slugs to return -- this fallback list
+// (the slugs assigned in docs/mariadb-setup.sql) keeps builds working in
+// the meantime. Once the migration runs, the real fetch below takes over
+// and this fallback is never reached.
+const FALLBACK_SLUGS = [
+  "ryans-portfolio",
+  "yield-report",
+  "epa-reporting",
+  "press-wip-optimization",
+  "gear-exchange-braintree",
+  "price-management-platform",
+  "ecms",
+  "turkey-handout-application",
+];
+
+export async function generateStaticParams() {
+  const projects = await getProjectsWithSlugs();
+
+  if (projects.length === 0) {
+    return FALLBACK_SLUGS.map((slug) => ({ slug }));
+  }
+
+  return projects.map((project) => ({ slug: project.slug }));
+}
+
+export async function generateMetadata({ params }) {
+  const { slug } = await params;
+  const project = await getProjectBySlug(slug);
+
+  if (!project) {
+    return { title: "Project not found" };
+  }
+
+  return {
+    title: project.title,
+    description: project.summary,
+    alternates: { canonical: `/projects/${project.slug}/` },
+    openGraph: {
+      title: project.title,
+      description: project.summary,
+      url: `/projects/${project.slug}/`,
+      images: project.image ? [{ url: project.image }] : undefined,
+    },
+    twitter: {
+      card: project.image ? "summary_large_image" : "summary",
+      title: project.title,
+      description: project.summary,
+      images: project.image ? [project.image] : undefined,
+    },
+  };
+}
+
+export default async function ProjectPage({ params }) {
+  const { slug } = await params;
+  const project = await getProjectBySlug(slug);
+
+  if (!project) {
+    return (
+      <main className="min-h-screen bg-stone-50 px-6 py-20 text-stone-900 dark:bg-stone-950 dark:text-stone-100">
+        <div className="mx-auto max-w-4xl rounded-3xl border border-stone-900/10 bg-white/90 p-10 dark:border-white/10 dark:bg-stone-900/80">
+          <h1 className="text-3xl font-semibold text-stone-900 dark:text-white">Project not found</h1>
+          <p className="mt-4 text-stone-600 dark:text-stone-300">The requested project could not be found.</p>
+          <Link
+            href="/"
+            className="mt-6 inline-flex items-center gap-2 text-orange-700 hover:text-orange-600 dark:text-orange-400 dark:hover:text-orange-300"
+          >
+            <FaArrowLeft /> Return home
+          </Link>
+        </div>
+      </main>
+    );
+  }
+
+  const techStackItems = project.techStack
+    ? project.techStack.split(",").map((item) => item.trim())
+    : [];
+
+  return (
+    <main className="min-h-screen bg-stone-50 text-stone-900 dark:bg-stone-950 dark:text-stone-100">
+      <section className="mx-auto max-w-4xl px-6 py-20 lg:px-8">
+        <Link
+          href="/#projects"
+          className="inline-flex items-center gap-2 text-sm text-orange-700 hover:text-orange-600 dark:text-orange-400 dark:hover:text-orange-300"
+        >
+          <FaArrowLeft /> Back to projects
+        </Link>
+
+        <div className="mt-6 overflow-hidden rounded-3xl border border-stone-900/10 bg-white/80 dark:border-white/10 dark:bg-stone-900/70">
+          {project.image && (
+            <div className="relative h-64 w-full sm:h-80">
+              <Image src={project.image} alt={project.title} fill className="object-cover" priority />
+            </div>
+          )}
+
+          <div className="p-8 lg:p-10">
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-orange-700 dark:text-orange-400">
+              {project.company}
+            </p>
+            <h1 className="mt-3 text-4xl font-semibold text-stone-900 dark:text-white">{project.title}</h1>
+            <p className="mt-6 text-lg leading-8 text-stone-600 dark:text-stone-300">{project.summary}</p>
+
+            {techStackItems.length > 0 && (
+              <div className="mt-6 flex flex-wrap gap-2">
+                {techStackItems.map((item) => (
+                  <span
+                    key={item}
+                    className="rounded-full border border-stone-900/10 bg-stone-100/70 px-3 py-1 text-xs font-medium text-stone-600 dark:border-white/10 dark:bg-stone-950/70 dark:text-stone-300"
+                  >
+                    {item}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {project.link && (
+              <a
+                href={project.link}
+                target="_blank"
+                rel="noreferrer"
+                className="mt-8 inline-flex items-center gap-2 rounded-full bg-orange-600 px-5 py-3 font-medium text-white transition hover:bg-orange-500 dark:bg-orange-500 dark:text-stone-950 dark:hover:bg-orange-400"
+              >
+                Visit project <FaArrowUpRightFromSquare />
+              </a>
+            )}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/app/sitemap.js
+++ b/src/app/sitemap.js
@@ -1,4 +1,4 @@
-import { getEmployers } from "@/lib/portfolio-data";
+import { getEmployers, getProjectsWithSlugs } from "@/lib/portfolio-data";
 
 export const dynamic = "force-static";
 
@@ -8,7 +8,7 @@ const siteUrl = "https://ryan.hurd.cc";
 // slash to match what the site actually serves -- otherwise crawlers see a
 // redirect instead of a 200 for every entry.
 export default async function sitemap() {
-  const employers = await getEmployers();
+  const [employers, projectsWithSlugs] = await Promise.all([getEmployers(), getProjectsWithSlugs()]);
 
   const staticRoutes = ["", "/resume"].map((path) => ({
     url: `${siteUrl}${path}/`,
@@ -20,5 +20,10 @@ export default async function sitemap() {
     lastModified: new Date(),
   }));
 
-  return [...staticRoutes, ...employerRoutes];
+  const projectRoutes = projectsWithSlugs.map((project) => ({
+    url: `${siteUrl}/projects/${project.slug}/`,
+    lastModified: new Date(),
+  }));
+
+  return [...staticRoutes, ...employerRoutes, ...projectRoutes];
 }

--- a/src/lib/portfolio-data.js
+++ b/src/lib/portfolio-data.js
@@ -440,6 +440,7 @@ export function normalizeImagePath(image) {
 export function normalizeProjectRows(rows) {
   return rows.map((row) => ({
     id: row.id,
+    slug: row.slug ?? null,
     title: row.title,
     summary: row.summary,
     image: normalizeImagePath(row.image),
@@ -480,6 +481,26 @@ export async function getProjectList() {
   }
 
   return normalizeProjectRows(projects);
+}
+
+// Only projects with a `slug` set get a dedicated /projects/[slug] page --
+// currently just the featured ones. No fallback list: if portfolio-api is
+// unreachable at build time, generateStaticParams just gets an empty
+// array and no detail pages are generated for that build (same
+// graceful-degradation pattern as everywhere else).
+export async function getProjectsWithSlugs() {
+  const projects = await fetchFromApi("/api/v1/projects?published=true");
+
+  if (!projects) {
+    return [];
+  }
+
+  return normalizeProjectRows(projects).filter((project) => project.slug);
+}
+
+export async function getProjectBySlug(slug) {
+  const projects = await getProjectsWithSlugs();
+  return projects.find((project) => project.slug === slug) ?? null;
 }
 
 export async function getEmployers() {


### PR DESCRIPTION
Closes #49.

## Summary
- New `/projects/[slug]` route following the `/experience/[slug]` pattern (generateStaticParams + generateMetadata + page component).
- Adds a `slug` column to `portfolio_projects` (migration 008), assigns slugs to the 8 currently-featured projects.
- Project History pills and carousel cards now link to the detail page when a project has a slug (beats an external `link` if both exist).
- Corresponding `portfolio-api` changes (Go model, store, schema) are pushed to that repo (commit 67c7cee) -- still needs a NAS redeploy for `slug` to round-trip live.
- Build-safe by design: since `output: "export"` requires at least one static param, and the live DB has zero slugs until the migration runs, there's a fallback slug list so this merges and builds cleanly regardless of DB timing. Pages show "Project not found" until the migration runs + API redeploys, then light up automatically on the next rebuild -- no second deploy needed.

## Test plan
- [x] `npm run build` succeeds (all 8 fallback + real routes generate)
- [x] `npx vitest run` -- 23/23 passing
- [x] Verified in-browser: not-found state renders correctly with proper templated metadata
- [x] Confirmed homepage doesn't show broken internal links pre-migration (falls back to external link/plain text as before)
- [ ] Once merged + migration run + API redeployed: verify a real detail page renders full content

🤖 Generated with [Claude Code](https://claude.com/claude-code)