### PR TITLE
Add shared hurd-footer web component to root layout

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -95,6 +95,8 @@ export default async function RootLayout({ children }) {
         />
         <SiteHeader employers={employers} />
         {children}
+        <script type="module" src="https://cdn.jsdelivr.net/gh/rh7112/hurd-footer@main/hurd-footer.js"></script>
+        <hurd-footer tagline="Ryan Hurd" link-href="https://github.com/rh7112"></hurd-footer>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Loads `rh7112/hurd-footer` via jsDelivr (`hurd-footer@main/hurd-footer.js`) and mounts `<hurd-footer>` in the root layout so it renders on every page.
- `tagline="Ryan Hurd"` and `link-href="https://github.com/rh7112"` — the package's own defaults (tagline "Hurd Archives", link back to ryan.hurd.cc) assume the component is embedded on a *different* site pointing back here, which doesn't fit since this site is ryan.hurd.cc itself.
- No site-specific styling needed: `--color-border`, `--color-text-muted`, `--color-accent` aren't defined in `globals.css`, so the component falls back to its own defaults.

## Test plan
- [x] Ran the dev server, confirmed `<hurd-footer>` mounts, `customElements.get('hurd-footer')` resolves, and its shadow DOM renders "Ryan Hurd" + `github.com/rh7112` link with no console/network errors.
- [ ] Visual check in a real browser (light + dark) once deployed to preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)