### PR TITLE
Use the Ryan Hurd logo as the header brand mark

### DIFF
--- a/src/app/components/SiteHeader.jsx
+++ b/src/app/components/SiteHeader.jsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useRef, useState } from "react";
 import { FaBars, FaChevronDown, FaTimes } from "react-icons/fa";
@@ -36,8 +37,15 @@ export default function SiteHeader({ employers = [] }) {
   return (
     <header className="sticky top-0 z-20 border-b border-stone-900/10 bg-stone-50/80 backdrop-blur dark:border-white/10 dark:bg-stone-950/80">
       <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4 lg:px-8">
-        <Link href="/" className="text-lg font-semibold uppercase tracking-[0.2em] text-stone-900 dark:text-white">
-          Ryan Hurd
+        <Link href="/" aria-label="Ryan Hurd" className="shrink-0">
+          <Image
+            src="/images/logo-no-background.png"
+            alt="Ryan Hurd"
+            width={1500}
+            height={939}
+            priority
+            className="h-14 w-auto"
+          />
         </Link>
 
         <div className="hidden items-center gap-4 text-sm text-stone-600 dark:text-stone-300 md:flex">


### PR DESCRIPTION
## Summary
- Replaces the plain-text "Ryan Hurd" nav brand link with `logo-no-background.png`, rendered at 56px tall in the header.
- The mark and wordmark are flattened into a single image (not separable without redrawing the artwork), so this swaps the text for the logo image itself rather than placing a small icon beside separate text.

## Note for reviewer
At normal header size the baked-in "Ryan Hurd" text reads as a recognizable wordmark shape but isn't fully crisp, since the text glyphs only occupy a small fraction of the source image's height. If it looks too small in practice, options are sizing it up (header gets taller) or sourcing a cleaner icon-only/vector version of the logo for crisper small rendering.

## Test plan
- [x] Verified in the dev server that the image loads (`naturalWidth`/`naturalHeight` match source, no console/network errors) and renders at the intended size.
- [x] Checked legibility by resizing the source PNG to the exact target pixel height and viewing it directly (the live screenshot tool wasn't available this session).
- [ ] Visual check in a real browser (light + dark) once deployed to preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)