### PR TITLE
Mark BBSystems.US as live and featured

### DIFF
--- a/docs/mariadb-setup.sql
+++ b/docs/mariadb-setup.sql
@@ -196,7 +196,7 @@ ON DUPLICATE KEY UPDATE summary = VALUES(summary), image = VALUES(image), compan
 -- clickable on the site instead of static text. Separate INSERT since these
 -- are the only rows in this file that set the `link` column.
 INSERT INTO portfolio_projects (title, summary, image, company, company_slug, color, tech_stack, link, featured, published) VALUES
-('BBSystems.US Website', 'An in-progress website project for BBSystems.US, currently in the planning stage while scoping requirements with the site''s owner, Cruz Gregory.', NULL, 'Personal Projects', 'personal-projects', 'sky', NULL, NULL, 0, 1),
+('BBSystems.US Website', 'Built and launched the BBSystems.US website for site owner Cruz Gregory.', NULL, 'Personal Projects', 'personal-projects', 'sky', NULL, 'https://bbsystems.us', 1, 1),
 ('blog.hurd.cc Extraction', 'Split the blog and recipes content out of this portfolio into its own site, including migrating the data into portfolio-api''s isolated hurd_blog database.', NULL, 'Personal Projects', 'personal-projects', 'sky', 'Next.js, portfolio-api', 'https://blog.hurd.cc', 0, 1),
 ('portfolio-api Swagger Docs', 'Set up Swagger/OpenAPI documentation for portfolio-api, giving a browsable, interactive reference for its REST endpoints.', NULL, 'Personal Projects', 'personal-projects', 'sky', 'Swagger/OpenAPI, Go', 'https://api.hurd.cc/docs/', 0, 1),
 ('Ramona Bauch, PA-C Website', 'Built a simple static portfolio website for Ramona Bauch, PA-C, deployed to Cloudflare Pages.', NULL, 'Personal Projects', 'personal-projects', 'sky', 'HTML, CSS, Cloudflare Pages', 'https://ramona.bauch.cc', 0, 1),


### PR DESCRIPTION
## Summary
- BBSystems.US has launched. Updates the `portfolio_projects` seed row in `docs/mariadb-setup.sql`:
  - Summary changed from "in-progress... planning stage" to reflect the site is built and live.
  - Added `link` = `https://bbsystems.us`.
  - `featured` flipped from `0` to `1`, so it can appear in the homepage's rotating featured-projects pool.

## Note for reviewer
This only updates the seed/documentation SQL file, not the live database directly — I don't have DB or portfolio-api admin credentials configured in this environment. The row's unique key is `(title, company_slug)` and the block it's in already runs as `INSERT ... ON DUPLICATE KEY UPDATE`, so re-running `docs/mariadb-setup.sql` against the `portfolio` database (or applying the equivalent `UPDATE portfolio_projects SET summary = ..., link = 'https://bbsystems.us', featured = 1 WHERE title = 'BBSystems.US Website' AND company_slug = 'personal-projects';`) is what actually applies this on the live site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)