### PR TITLE
Show all employer projects; unify contact links across pages

### DIFF
--- a/src/app/components/ContactLinks.jsx
+++ b/src/app/components/ContactLinks.jsx
@@ -1,0 +1,42 @@
+import { FaEnvelope, FaFileAlt, FaGithub, FaLinkedin, FaPhoneAlt } from "react-icons/fa";
+import { SiIndeed } from "react-icons/si";
+
+// Single source of truth for the static contact links used on the resume
+// and employer detail pages -- these two pages used to keep their own
+// hand-copied lists, which had already drifted (different labels, the
+// employer page's Indeed link missing from the resume page).
+//
+// The homepage's contact section is intentionally separate: it's driven by
+// portfolio-api content (contactHeading/contactBody/contactLinks), editable
+// without a code change, not duplicated by hand.
+export const contactLinks = [
+  { label: "Email", href: "mailto:rh25170@gmail.com", icon: FaEnvelope },
+  { label: "Phone", href: "tel:+13525800408", icon: FaPhoneAlt },
+  { label: "GitHub", href: "https://github.com/rh7112", icon: FaGithub },
+  { label: "LinkedIn", href: "https://www.linkedin.com/in/ryan-lee-hurd/", icon: FaLinkedin },
+  { label: "Resume", href: "/documents/ryan-hurd-resume.pdf", icon: FaFileAlt },
+  { label: "Indeed", href: "https://profile.indeed.com/p/ryanh-sv25zg9", icon: SiIndeed },
+];
+
+export default function ContactLinks({ size = "md", className = "" }) {
+  const padding = size === "sm" ? "px-4 py-2" : "px-4 py-3";
+
+  return (
+    <div className={`flex flex-wrap gap-3 ${className}`}>
+      {contactLinks.map((link) => {
+        const Icon = link.icon;
+        return (
+          <a
+            key={link.label}
+            href={link.href}
+            target={link.href.startsWith("http") ? "_blank" : undefined}
+            rel={link.href.startsWith("http") ? "noreferrer" : undefined}
+            className={`inline-flex items-center gap-2 rounded-full border border-stone-900/10 bg-stone-100/70 ${padding} text-sm font-medium text-stone-700 transition hover:border-orange-600 hover:text-stone-900 dark:border-white/10 dark:bg-stone-950/70 dark:text-stone-200 dark:hover:border-orange-400 dark:hover:text-white`}
+          >
+            <Icon /> {link.label}
+          </a>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/experience/[slug]/page.js
+++ b/src/app/experience/[slug]/page.js
@@ -1,8 +1,8 @@
 import Link from "next/link";
 import Image from "next/image";
-import { FaArrowLeft, FaEnvelope, FaFileAlt, FaGithub, FaLinkedin, FaPhoneAlt } from "react-icons/fa";
-import { SiIndeed } from "react-icons/si";
-import { getEmployerBySlug, getEmployers } from "@/lib/portfolio-data";
+import { FaArrowLeft } from "react-icons/fa";
+import ContactLinks from "@/app/components/ContactLinks";
+import { getEmployerBySlug, getEmployers, getProjectsByCompanySlug } from "@/lib/portfolio-data";
 
 export async function generateStaticParams() {
   const employers = await getEmployers();
@@ -55,14 +55,7 @@ export default async function EmployerPage({ params }) {
     );
   }
 
-  const contactLinks = [
-    { label: "Email", href: "mailto:rh25170@gmail.com", icon: FaEnvelope },
-    { label: "Phone", href: "tel:+13525800408", icon: FaPhoneAlt },
-    { label: "GitHub", href: "https://github.com/rh7112", icon: FaGithub },
-    { label: "LinkedIn", href: "https://www.linkedin.com/in/ryan-lee-hurd/", icon: FaLinkedin },
-    { label: "Resume", href: "/documents/ryan-hurd-resume.pdf", icon: FaFileAlt },
-    { label: "Indeed", href: "https://profile.indeed.com/p/ryanh-sv25zg9", icon: SiIndeed },
-  ];
+  const projects = await getProjectsByCompanySlug(slug);
 
   return (
     <main className="min-h-screen bg-stone-50 text-stone-900 dark:bg-stone-950 dark:text-stone-100">
@@ -91,24 +84,43 @@ export default async function EmployerPage({ params }) {
         </section>
       )}
 
-      {employer.caseStudies?.length > 0 && (
+      {projects.length > 0 && (
         <section className="mx-auto max-w-6xl px-6 py-8 lg:px-8">
           <div className="rounded-3xl border border-stone-900/10 bg-white/70 p-8 dark:border-white/10 dark:bg-stone-900/60 lg:p-10">
-            <h2 className="text-3xl font-semibold text-stone-900 dark:text-white">Featured work</h2>
+            <h2 className="text-3xl font-semibold text-stone-900 dark:text-white">Projects</h2>
             <div className="mt-8 grid gap-6 lg:grid-cols-3">
-              {employer.caseStudies.map((project) => (
-                <article key={project.title} className="overflow-hidden rounded-3xl border border-stone-900/10 bg-stone-100/70 dark:border-white/10 dark:bg-stone-950/70">
-                  {project.image && (
-                    <div className="relative h-48 w-full">
-                      <Image src={project.image} alt={project.title} fill className="object-cover" />
+              {projects.map((project) => {
+                const href = project.slug ? `/projects/${project.slug}` : project.link;
+                const card = (
+                  <article className="overflow-hidden rounded-3xl border border-stone-900/10 bg-stone-100/70 dark:border-white/10 dark:bg-stone-950/70">
+                    {project.image && (
+                      <div className="relative h-48 w-full">
+                        <Image src={project.image} alt={project.title} fill className="object-cover" />
+                      </div>
+                    )}
+                    <div className="p-6">
+                      <h3 className="text-xl font-semibold text-stone-900 dark:text-white">{project.title}</h3>
+                      <p className="mt-3 text-sm leading-7 text-stone-600 dark:text-stone-300">{project.summary}</p>
                     </div>
-                  )}
-                  <div className="p-6">
-                    <h3 className="text-xl font-semibold text-stone-900 dark:text-white">{project.title}</h3>
-                    <p className="mt-3 text-sm leading-7 text-stone-600 dark:text-stone-300">{project.summary}</p>
-                  </div>
-                </article>
-              ))}
+                  </article>
+                );
+
+                if (!href) {
+                  return <div key={project.id}>{card}</div>;
+                }
+
+                return (
+                  <Link
+                    key={project.id}
+                    href={href}
+                    target={href.startsWith("http") ? "_blank" : undefined}
+                    rel={href.startsWith("http") ? "noreferrer" : undefined}
+                    className="block transition hover:-translate-y-0.5"
+                  >
+                    {card}
+                  </Link>
+                );
+              })}
             </div>
           </div>
         </section>
@@ -117,22 +129,7 @@ export default async function EmployerPage({ params }) {
       <section className="mx-auto max-w-6xl px-6 py-16 lg:px-8">
         <div className="rounded-3xl border border-orange-600/20 bg-gradient-to-br from-stone-100 to-stone-50 p-8 dark:border-orange-500/20 dark:from-stone-900 dark:to-stone-950 lg:p-10">
           <h2 className="text-3xl font-semibold text-stone-900 dark:text-white">Contact</h2>
-          <div className="mt-8 flex flex-wrap gap-3">
-            {contactLinks.map((link) => {
-              const Icon = link.icon;
-              return (
-                <a
-                  key={link.label}
-                  href={link.href}
-                  target={link.href.startsWith("http") ? "_blank" : undefined}
-                  rel={link.href.startsWith("http") ? "noreferrer" : undefined}
-                  className="inline-flex items-center gap-2 rounded-full border border-stone-900/10 bg-stone-100/70 px-4 py-3 text-sm font-medium text-stone-700 transition hover:border-orange-600 hover:text-stone-900 dark:border-white/10 dark:bg-stone-950/70 dark:text-stone-200 dark:hover:border-orange-400 dark:hover:text-white"
-                >
-                  <Icon /> {link.label}
-                </a>
-              );
-            })}
-          </div>
+          <ContactLinks className="mt-8" />
         </div>
       </section>
     </main>

--- a/src/app/resume/page.js
+++ b/src/app/resume/page.js
@@ -1,5 +1,6 @@
 import Link from "next/link";
-import { FaArrowLeft, FaEnvelope, FaFileAlt, FaGithub, FaLinkedin, FaPhoneAlt } from "react-icons/fa";
+import { FaArrowLeft } from "react-icons/fa";
+import ContactLinks from "@/app/components/ContactLinks";
 import { getCertifications, getEducation, getEmployers } from "@/lib/portfolio-data";
 
 export const metadata = {
@@ -12,14 +13,6 @@ export const metadata = {
     url: "/resume/",
   },
 };
-
-const contactLinks = [
-  { label: "Email", href: "mailto:rh25170@gmail.com", icon: FaEnvelope },
-  { label: "Phone", href: "tel:+13525800408", icon: FaPhoneAlt },
-  { label: "GitHub", href: "https://github.com/rh7112", icon: FaGithub },
-  { label: "LinkedIn", href: "https://www.linkedin.com/in/ryan-lee-hurd/", icon: FaLinkedin },
-  { label: "PDF version", href: "/documents/ryan-hurd-resume.pdf", icon: FaFileAlt },
-];
 
 export default async function ResumePage() {
   const [employers, education, certifications] = await Promise.all([
@@ -42,22 +35,7 @@ export default async function ResumePage() {
           <h1 className="text-4xl font-semibold text-stone-900 dark:text-white">Ryan Hurd</h1>
           <p className="mt-2 text-lg text-stone-600 dark:text-stone-300">Software Engineer</p>
 
-          <div className="no-print mt-6 flex flex-wrap gap-3">
-            {contactLinks.map((link) => {
-              const Icon = link.icon;
-              return (
-                <a
-                  key={link.label}
-                  href={link.href}
-                  target={link.href.startsWith("http") ? "_blank" : undefined}
-                  rel={link.href.startsWith("http") ? "noreferrer" : undefined}
-                  className="inline-flex items-center gap-2 rounded-full border border-stone-900/10 bg-stone-100/70 px-4 py-2 text-sm font-medium text-stone-700 transition hover:border-orange-600 hover:text-stone-900 dark:border-white/10 dark:bg-stone-950/70 dark:text-stone-200 dark:hover:border-orange-400 dark:hover:text-white"
-                >
-                  <Icon /> {link.label}
-                </a>
-              );
-            })}
-          </div>
+          <ContactLinks size="sm" className="no-print mt-6" />
         </div>
 
         <section className="mt-8">

--- a/src/lib/portfolio-data.js
+++ b/src/lib/portfolio-data.js
@@ -503,6 +503,19 @@ export async function getProjectBySlug(slug) {
   return projects.find((project) => project.slug === slug) ?? null;
 }
 
+// All published projects tied to one company (both featured and
+// non-featured) -- used on the employer detail page, which shows the full
+// project list rather than the homepage's featured/non-featured split.
+export async function getProjectsByCompanySlug(companySlug) {
+  const projects = await fetchFromApi("/api/v1/projects?published=true");
+
+  if (!projects) {
+    return [];
+  }
+
+  return normalizeProjectRows(projects).filter((project) => project.companySlug === companySlug);
+}
+
 export async function getEmployers() {
   const employers = await fetchFromApi("/api/v1/employers");
 


### PR DESCRIPTION
## Summary
- `/experience/[slug]` now lists every published project tied to that employer (new `getProjectsByCompanySlug`) instead of the separate, hand-curated `caseStudies` list — heading renamed "Featured work" → "Projects".
- Resume and employer pages had two separately hand-copied contact link lists that had already drifted (different labels, employer page's Indeed link missing from resume). Extracted both into a shared `ContactLinks` component.
- Homepage's contact section intentionally left alone — it's driven by portfolio-api content, editable without a code change, a different (and fine) system.

## After merging
- [ ] The new "Projects" section will render empty for every employer until portfolio-api#24 is merged AND its migration is run against production (verified locally that /api/v1/projects currently 500s) — come back and confirm real project cards render once that's done

## Test plan
- [x] Verified locally: employer page renders "Projects" heading, contact links now identical set/order on resume + employer pages
- [ ] Re-check after portfolio-api#24's migration is applied that real project cards render