### PR TITLE
Add HTTP security headers (CSP, X-Frame-Options, etc.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ yarn-error.log*
 # vercel
 .vercel
 
+# wrangler
+.wrangler
+
 # typescript
 *.tsbuildinfo
 next-env.d.ts

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,5 @@
+/*
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'
+  X-Frame-Options: DENY
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin


### PR DESCRIPTION
## Summary
Closes #82. Adds `public/_headers` (Cloudflare's static-asset header file, copied into `out/` by Next's static export) with:
- `Content-Security-Policy` — `default-src 'self'`, explicitly allows the jsdelivr-hosted `<hurd-footer>` script, `'unsafe-inline'` for script/style (Next's static export ships inline hydration bootstrap scripts and inline `style=""` attributes that a static header file can't nonce per-request — no server involved to generate one), `frame-ancestors 'none'`, `object-src 'none'`.
- `X-Frame-Options: DENY`
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`

Also gitignores `.wrangler/` (local cache dir from verifying this via `wrangler dev`, wasn't ignored before).

## Verification
- Confirmed via `wrangler dev` (the only local server that actually honors `_headers` — plain `next start`/static file servers don't) that the headers apply to real responses.
- Loaded the site in a browser against that server: page renders and hydrates fully, zero console errors, and the jsdelivr `<hurd-footer>` script loads and renders into its shadow root correctly under the CSP allowlist.

## After merging
- No manual steps — static header file, takes effect on next deploy automatically.